### PR TITLE
Update EntityVehicleA_Base.java

### DIFF
--- a/main/java/minecrafttransportsimulator/vehicles/main/EntityVehicleA_Base.java
+++ b/main/java/minecrafttransportsimulator/vehicles/main/EntityVehicleA_Base.java
@@ -101,7 +101,7 @@ public abstract class EntityVehicleA_Base extends Entity{
 		if(!ignoreCollision){
 			//Check for collision, and boost if needed.
 			if(part.isPartCollidingWithBlocks(Vec3d.ZERO)){
-				this.setPositionAndRotation(posX, posY +  Math.max(0, -part.offset.y) + part.getHeight(), posZ, rotationYaw, rotationPitch);
+				this.setPositionAndRotation(posX, posY + part.getHeight(), posZ, rotationYaw, rotationPitch);
 			}
 			
 			//Sometimes we need to do this for parts that are deeper into the ground.


### PR DESCRIPTION
Removed Math.max(0, -part.offset.y) in the 'boost' section. This prevents planes with tall landing gear from jumping up and exploding on landing. This may cause parts to stick in the ground, but most wheels are at 0,0,0, in which case this doesn't do anything anyway.