### PR TITLE
Turret rotation limit

### DIFF
--- a/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
+++ b/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
@@ -88,10 +88,10 @@ public class JSONPart extends AJSONMultiModel<JSONPart.PartGeneral>{
     	public int fireDelay;
     	public int reloadTime;
     	public int muzzleVelocity;
-    	public int minPitch;
-    	public int maxPitch;
-    	public int minYaw;
-    	public int maxYaw;
+    	public float minPitch;
+    	public float maxPitch;
+    	public float minYaw;
+    	public float maxYaw;
     	public float diameter;
     	public float length;
     }

--- a/src/main/java/minecrafttransportsimulator/vehicles/parts/APartGun.java
+++ b/src/main/java/minecrafttransportsimulator/vehicles/parts/APartGun.java
@@ -180,17 +180,18 @@ public abstract class APartGun extends APart<EntityVehicleE_Powered> implements 
 				//When we do yaw, make sure we do calculations with positive values.
 				//Both the vehicle and the player can have yaw greater than 360.
 				double deltaPitch = playerController.rotationPitch - vehicle.rotationPitch;
-				double deltaYaw = (playerController.rotationYaw + 360)%360 - (vehicle.rotationYaw + 360 - partRotation.y + 360)%360;
+				double deltaYaw = (playerController.rotationYaw + 360 - vehicle.rotationYaw + 360 + partRotation.y + 360)%360;
 				if(deltaPitch < currentPitch && currentPitch > getMinPitch()){
 					currentPitch -= Math.min(anglePerTickSpeed, currentPitch - deltaPitch);
 				}else if(deltaPitch > currentPitch && currentPitch < getMaxPitch()){
 					currentPitch += Math.min(anglePerTickSpeed, deltaPitch - currentPitch);
 				}
 				if(getMinYaw() > 0  && getMaxYaw() < 0) {
-					if(deltaYaw < currentYaw){
-						currentYaw -= Math.min(anglePerTickSpeed, currentYaw - deltaYaw);
-					}else if(deltaYaw > currentYaw){
-						currentYaw += Math.min(anglePerTickSpeed, deltaYaw - currentYaw);
+					if((deltaYaw - currentYaw + 360)%360 >= 180) {
+						currentYaw -= Math.min(anglePerTickSpeed,360 - (deltaYaw - currentYaw + 360)%360);
+					}
+					else if((deltaYaw - currentYaw + 360)%360 < 180) {
+						currentYaw += Math.min(anglePerTickSpeed,(deltaYaw - currentYaw + 360)%360);
 					}
 					if(currentYaw > 180 ) currentYaw -= 360;
 					else if(currentYaw < -180) currentYaw += 360;

--- a/src/main/java/minecrafttransportsimulator/vehicles/parts/APartGun.java
+++ b/src/main/java/minecrafttransportsimulator/vehicles/parts/APartGun.java
@@ -186,17 +186,20 @@ public abstract class APartGun extends APart<EntityVehicleE_Powered> implements 
 				}else if(deltaPitch > currentPitch && currentPitch < getMaxPitch()){
 					currentPitch += Math.min(anglePerTickSpeed, deltaPitch - currentPitch);
 				}
-				if(getMinYaw() > 0  && getMaxYaw() < 0) {
-					if((deltaYaw - currentYaw + 360)%360 >= 180) {
+				//If yaw is from -180 to 180, we are a gun that can spin around on its mount.
+				//We need to do special rotation logic for that.
+				if(getMinYaw() == -180  && getMaxYaw() == 180){
+					if((deltaYaw - currentYaw + 360)%360 >= 180){
 						currentYaw -= Math.min(anglePerTickSpeed,360 - (deltaYaw - currentYaw + 360)%360);
-					}
-					else if((deltaYaw - currentYaw + 360)%360 < 180) {
+					}else if((deltaYaw - currentYaw + 360)%360 < 180){
 						currentYaw += Math.min(anglePerTickSpeed,(deltaYaw - currentYaw + 360)%360);
 					}
-					if(currentYaw > 180 ) currentYaw -= 360;
-					else if(currentYaw < -180) currentYaw += 360;
-				}
-				else {
+					if(currentYaw > 180 ){
+						currentYaw -= 360;
+					}else if(currentYaw < -180){
+						currentYaw += 360;
+					}
+				}else{
 					if(deltaYaw < currentYaw && currentYaw > getMinYaw()){
 						currentYaw -= Math.min(anglePerTickSpeed, currentYaw - deltaYaw);
 					}else if(deltaYaw > currentYaw && currentYaw < getMaxYaw()){

--- a/src/main/java/minecrafttransportsimulator/vehicles/parts/APartGun.java
+++ b/src/main/java/minecrafttransportsimulator/vehicles/parts/APartGun.java
@@ -180,16 +180,27 @@ public abstract class APartGun extends APart<EntityVehicleE_Powered> implements 
 				//When we do yaw, make sure we do calculations with positive values.
 				//Both the vehicle and the player can have yaw greater than 360.
 				double deltaPitch = playerController.rotationPitch - vehicle.rotationPitch;
-				double deltaYaw = (playerController.rotationYaw%360 + 360)%360 - (vehicle.rotationYaw%360 - partRotation.y + 360)%360;
+				double deltaYaw = (playerController.rotationYaw + 360)%360 - (vehicle.rotationYaw + 360 - partRotation.y + 360)%360;
 				if(deltaPitch < currentPitch && currentPitch > getMinPitch()){
 					currentPitch -= Math.min(anglePerTickSpeed, currentPitch - deltaPitch);
 				}else if(deltaPitch > currentPitch && currentPitch < getMaxPitch()){
 					currentPitch += Math.min(anglePerTickSpeed, deltaPitch - currentPitch);
 				}
-				if(deltaYaw < currentYaw && currentYaw > getMinYaw()){
-					currentYaw -= Math.min(anglePerTickSpeed, currentYaw - deltaYaw);
-				}else if(deltaYaw > currentYaw && currentYaw < getMaxYaw()){
-					currentYaw += Math.min(anglePerTickSpeed, deltaYaw - currentYaw);
+				if(getMinYaw() > 0  && getMaxYaw() < 0) {
+					if(deltaYaw < currentYaw){
+						currentYaw -= Math.min(anglePerTickSpeed, currentYaw - deltaYaw);
+					}else if(deltaYaw > currentYaw){
+						currentYaw += Math.min(anglePerTickSpeed, deltaYaw - currentYaw);
+					}
+					if(currentYaw > 180 ) currentYaw -= 360;
+					else if(currentYaw < -180) currentYaw += 360;
+				}
+				else {
+					if(deltaYaw < currentYaw && currentYaw > getMinYaw()){
+						currentYaw -= Math.min(anglePerTickSpeed, currentYaw - deltaYaw);
+					}else if(deltaYaw > currentYaw && currentYaw < getMaxYaw()){
+						currentYaw += Math.min(anglePerTickSpeed, deltaYaw - currentYaw);
+					}
 				}
 			}else{
 				playerControllerID = -1;

--- a/src/main/java/minecrafttransportsimulator/vehicles/parts/APartGun.java
+++ b/src/main/java/minecrafttransportsimulator/vehicles/parts/APartGun.java
@@ -181,9 +181,11 @@ public abstract class APartGun extends APart<EntityVehicleE_Powered> implements 
 				//Both the vehicle and the player can have yaw greater than 360.
 				double deltaPitch = playerController.rotationPitch - vehicle.rotationPitch;
 				double deltaYaw = (playerController.rotationYaw + 360 - vehicle.rotationYaw + 360 + partRotation.y + 360)%360;
-				if(deltaPitch < currentPitch && currentPitch > getMinPitch()){
+				//I know this is weird, but the pitch is bigger when it's pointing the ground and smaller when it's pointing the sky.
+				//At least this won't be confusing on the pack creator's end in this way. -Bunting_chj
+				if(deltaPitch < currentPitch && currentPitch > -getMaxPitch()){
 					currentPitch -= Math.min(anglePerTickSpeed, currentPitch - deltaPitch);
-				}else if(deltaPitch > currentPitch && currentPitch < getMaxPitch()){
+				}else if(deltaPitch > currentPitch && currentPitch < -getMinPitch()){
 					currentPitch += Math.min(anglePerTickSpeed, deltaPitch - currentPitch);
 				}
 				//If yaw is from -180 to 180, we are a gun that can spin around on its mount.

--- a/src/main/java/minecrafttransportsimulator/vehicles/parts/APartGun.java
+++ b/src/main/java/minecrafttransportsimulator/vehicles/parts/APartGun.java
@@ -199,6 +199,12 @@ public abstract class APartGun extends APart<EntityVehicleE_Powered> implements 
 					}else if(currentYaw < -180){
 						currentYaw += 360;
 					}
+					
+					//If we crossed the -180/180 yaw border this tick, change prevYaw to prevent spazzing.
+					//We know this if we have a sign difference, and yaw is large.
+					if(prevYaw*currentYaw < 0 && prevYaw*currentYaw < -180){
+						prevYaw += prevYaw < 0 ? 360 : -360;
+					}
 				}else{
 					if(deltaYaw < currentYaw && currentYaw > getMinYaw()){
 						currentYaw -= Math.min(anglePerTickSpeed, currentYaw - deltaYaw);

--- a/src/main/java/minecrafttransportsimulator/vehicles/parts/PartGunTripod.java
+++ b/src/main/java/minecrafttransportsimulator/vehicles/parts/PartGunTripod.java
@@ -13,25 +13,21 @@ public class PartGunTripod extends APartGun{
 	
 	@Override
 	public float getMinYaw(){
-		if (definition.gun.minYaw == 0) return -45;
-		else return definition.gun.minYaw;
+		return definition.gun.minYaw == 0 ? -45 : definition.gun.minYaw;
 	}
 	
 	@Override
 	public float getMaxYaw(){
-		if (definition.gun.maxYaw == 0) return 45;
-		else return definition.gun.maxYaw;
+		return definition.gun.maxYaw == 0 ? 45 : definition.gun.maxYaw;
 	}
 	
 	@Override
 	public float getMinPitch(){
-		if (definition.gun.minPitch == 0) return -35;
-		else return definition.gun.minPitch;
+		return definition.gun.minPitch == 0 ? -35 : definition.gun.minPitch;
 	}
 	
 	@Override
 	public float getMaxPitch(){
-		if (definition.gun.maxPitch == 0) return 35;
-		else return definition.gun.maxPitch;
+		return definition.gun.maxPitch == 0 ? 35 : definition.gun.maxPitch;
 	}
 }

--- a/src/main/java/minecrafttransportsimulator/vehicles/parts/PartGunTripod.java
+++ b/src/main/java/minecrafttransportsimulator/vehicles/parts/PartGunTripod.java
@@ -13,21 +13,25 @@ public class PartGunTripod extends APartGun{
 	
 	@Override
 	public float getMinYaw(){
-		return -45;
+		if (definition.gun.minYaw == 0) return -45;
+		else return definition.gun.minYaw;
 	}
 	
 	@Override
 	public float getMaxYaw(){
-		return 45;
+		if (definition.gun.maxYaw == 0) return 45;
+		else return definition.gun.maxYaw;
 	}
 	
 	@Override
 	public float getMinPitch(){
-		return -35;
+		if (definition.gun.minPitch == 0) return -35;
+		else return definition.gun.minPitch;
 	}
 	
 	@Override
 	public float getMaxPitch(){
-		return 35;
+		if (definition.gun.maxPitch == 0) return 35;
+		else return definition.gun.maxPitch;
 	}
 }

--- a/src/main/java/minecrafttransportsimulator/vehicles/parts/PartGunTurret.java
+++ b/src/main/java/minecrafttransportsimulator/vehicles/parts/PartGunTurret.java
@@ -17,24 +17,28 @@ public class PartGunTurret extends APartGun{
 		//Don't return pitch here, as turrets don't pitch up, only their barrels do.
 		return new Vec3d(0, currentYaw - (currentYaw - prevYaw)*(1 - partialTicks), 0);
 	}
-	
+
 	@Override
 	public float getMinYaw(){
-		return 1;
+		if (definition.gun.minYaw == 0) return 1;
+		else return definition.gun.minYaw;
 	}
 	
 	@Override
 	public float getMaxYaw(){
-		return -1;
+		if (definition.gun.maxYaw == 0) return -1;
+		else return definition.gun.maxYaw;
 	}
 	
 	@Override
 	public float getMinPitch(){
-		return -75;
+		if (definition.gun.minPitch == 0) return 0;
+		else return definition.gun.minPitch;
 	}
 	
 	@Override
 	public float getMaxPitch(){
-		return 0;
+		if (definition.gun.maxPitch == 0) return 75;
+		else return definition.gun.maxPitch;
 	}
 }

--- a/src/main/java/minecrafttransportsimulator/vehicles/parts/PartGunTurret.java
+++ b/src/main/java/minecrafttransportsimulator/vehicles/parts/PartGunTurret.java
@@ -35,6 +35,6 @@ public class PartGunTurret extends APartGun{
 	
 	@Override
 	public float getMaxPitch(){
-		return definition.gun.minPitch == 0 ? 60 : definition.gun.minPitch;
+		return definition.gun.maxPitch == 0 ? 60 : definition.gun.maxPitch;
 	}
 }

--- a/src/main/java/minecrafttransportsimulator/vehicles/parts/PartGunTurret.java
+++ b/src/main/java/minecrafttransportsimulator/vehicles/parts/PartGunTurret.java
@@ -20,12 +20,12 @@ public class PartGunTurret extends APartGun{
 	
 	@Override
 	public float getMinYaw(){
-		return -180;
+		return 1;
 	}
 	
 	@Override
 	public float getMaxYaw(){
-		return 180;
+		return -1;
 	}
 	
 	@Override

--- a/src/main/java/minecrafttransportsimulator/vehicles/parts/PartGunTurret.java
+++ b/src/main/java/minecrafttransportsimulator/vehicles/parts/PartGunTurret.java
@@ -20,25 +20,21 @@ public class PartGunTurret extends APartGun{
 
 	@Override
 	public float getMinYaw(){
-		if (definition.gun.minYaw == 0) return 1;
-		else return definition.gun.minYaw;
+		return definition.gun.minYaw == 0 ? -180 : definition.gun.minYaw;
 	}
 	
 	@Override
 	public float getMaxYaw(){
-		if (definition.gun.maxYaw == 0) return -1;
-		else return definition.gun.maxYaw;
+		return definition.gun.maxYaw == 0 ? 180 : definition.gun.maxYaw;
 	}
 	
 	@Override
 	public float getMinPitch(){
-		if (definition.gun.minPitch == 0) return 0;
-		else return definition.gun.minPitch;
+		return definition.gun.minPitch == 0 ? -10 : definition.gun.minPitch;
 	}
 	
 	@Override
 	public float getMaxPitch(){
-		if (definition.gun.maxPitch == 0) return 75;
-		else return definition.gun.maxPitch;
+		return definition.gun.minPitch == 0 ? 60 : definition.gun.minPitch;
 	}
 }


### PR DESCRIPTION
Tripod Gun and Turret Gun now looks at JSON def for their rotation limits. if there is no value in JSON(that equals 0), they use default values. If the limit needs to be 0, JSON must have some value close enough to it.
Turrets can rotate around without limit if the minYaw is positive & maxYaw is negative.

Since the suggestion I made about separating the gun into shooting part on traversing part would take some time, this would do until I figure out how.