### PR TITLE
Pole components used in survival mode will subtract normally.

### DIFF
--- a/src/main/java/minecrafttransportsimulator/packets/instances/PacketTileEntityPoleChange.java
+++ b/src/main/java/minecrafttransportsimulator/packets/instances/PacketTileEntityPoleChange.java
@@ -123,6 +123,14 @@ public class PacketTileEntityPoleChange extends APacketTileEntity<TileEntityPole
 					newComponent.setTextLines(textLines);
 				}
 				pole.updateLightState();
+				//if player is not in creative mod, try to subtract the component.
+				if(!player.isCreative()){
+					ItemStack componentStack = player.getHeldStack();
+					componentStack.shrink(1);
+					if(componentStack.isEmpty()){
+						player.removeItem(componentStack);
+					}
+				}
 				return true;
 			} 
 		}


### PR DESCRIPTION
There was a minor bug that used signs&traffic lights won't decrease in item number. Changed it in the PacketTileEntityPoleChange class to shrink the item stack size, and remove it if it's empty.