### PR TITLE
"revResistance" part 1

### DIFF
--- a/src/main/java/minecrafttransportsimulator/vehicles/parts/PartEngine.java
+++ b/src/main/java/minecrafttransportsimulator/vehicles/parts/PartEngine.java
@@ -95,6 +95,9 @@ public class PartEngine extends APart implements IVehiclePartFXProvider{
 				++reverseGears;
 			}
 		}
+		if (definition.engine.revResistance <= 0){
+				definition.engine.revResistance = 10;
+		}
 		this.startRPM = definition.engine.maxRPM < 15000 ? 500 : 2000;
 		this.stallRPM = definition.engine.maxRPM < 15000 ? 300 : 1500;
 		
@@ -365,7 +368,7 @@ public class PartEngine extends APart implements IVehiclePartFXProvider{
 				//Don't adjust it down to stall the engine, that can only be done via backfire.
 				if(wheelFriction > 0){
 					double desiredRPM = lowestWheelVelocity*1200F*currentGearRatio*vehicle.definition.motorized.axleRatio;
-					rpm += (desiredRPM - rpm)/10D;
+					rpm += (desiredRPM - rpm)/definition.engine.revResistance;
 					if(rpm < stallRPM && state.running){
 						rpm = stallRPM;
 					}
@@ -430,9 +433,9 @@ public class PartEngine extends APart implements IVehiclePartFXProvider{
 		if((wheelFriction == 0 && !havePropeller) || currentGearRatio == 0){
 			if(state.running){
 				double engineTargetRPM = vehicle.throttle/100F*(definition.engine.maxRPM - startRPM*1.25 - hours*10) + startRPM*1.25;
-				rpm += (engineTargetRPM - rpm)/10;
+				rpm += (engineTargetRPM - rpm)/(definition.engine.revResistance*3);
 				if(rpm > getSafeRPMFromMax(definition.engine.maxRPM) && definition.engine.jetPowerFactor == 0){
-					rpm -= Math.abs(engineTargetRPM - rpm)/5;
+					rpm -= Math.abs(engineTargetRPM - rpm)/definition.engine.revResistance;
 				}
 			}else if(!state.esOn && !state.hsOn){
 				rpm = Math.max(rpm - 10, 0);


### PR DESCRIPTION
Still trying to figure out my way around github, and might have to make another PR just for the partjson java file. If not i'll just edit the description

Words to read:
What does this do:
Makes engines revv slower or faster depending on how high or low the value is.
If the value is "0" or negative the engine  will default it to 10.

What does it change:
Originally a hard coded value, (10) this controls how fast the engine revvs in idle and how fast the engine accelerates.
The most notable difference is that engines in neutral rev slower, and have a bit less redline kickback, though hopefully it shouldn't be an issue. Otherwise, there shouldn't be any visible changes to current engines without a "revResistance" value
Engines with a "revResistance" value lower than 10 should notice a quick change in RPMs, rather than trying to play "catch up" and failing.

Why would this be needed:
The engine RPM is playing a game of "catch up" and sometimes the engine can't actually catch up. Most visible on cars with close gear ratios or that accelerate quickly.