### PR TITLE
"revResistance" part 2

### DIFF
--- a/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
+++ b/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
@@ -43,6 +43,7 @@ public class JSONPart extends AJSONMultiModel<JSONPart.JSONPartGeneral>{
     	public byte starterPower;
     	public byte shiftSpeed;
     	public int maxRPM;
+	public byte revResistance;
     	public float fuelConsumption;
     	public float jetPowerFactor;
     	public float bypassRatio;


### PR DESCRIPTION
It's literally just adding that value thing here
_REMINDER THAT IF YOU WANT ME TO RESPOND TO SOMETHING YOU MUST TELL ME IN THE MTS DISCORD! I DO NOT USE GITHUB VERY OFTEN, AND IT TOOK A GOOD CHUNK OF MY DAY JUST FOR THE WEBPAGE TO LOAD WITHOUT FAILING_

[Part 1](https://github.com/DonBruce64/MinecraftTransportSimulator/pull/531)

Copied and pasted description from other Pull Request

Words to read:
What does this do:
Makes engines revv slower or faster depending on how high or low the value is.
If the value is "0" or negative the engine  will default it to 10.

What does it change:
Originally a hard coded value, (10) this controls how fast the engine revvs in idle and how fast the engine accelerates.
The most notable difference is that engines in neutral rev slower, and have a bit less redline kickback, though hopefully it shouldn't be an issue. Otherwise, there shouldn't be any visible changes to current engines without a "revResistance" value
Engines with a "revResistance" value lower than 10 should notice a quick change in RPMs, rather than trying to play "catch up" and failing.

Why would this be needed:
The engine RPM is playing a game of "catch up" and sometimes the engine can't actually catch up. Most visible on cars with close gear ratios or that accelerate quickly.