### PR TITLE
Fixes rockets sometimes firing in the wrong direction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 apply plugin: 'net.minecraftforge.gradle.forge'
 apply plugin: 'com.github.johnrengelman.shadow'
 
-version = "1.12.2-19.9.0"
+version = "1.12.2-19.9.1_BETA1"
 group= "minecrafttransportsimulator" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "Immersive Vehicles"
 

--- a/src/main/java/minecrafttransportsimulator/rendering/instances/ParticleMissile.java
+++ b/src/main/java/minecrafttransportsimulator/rendering/instances/ParticleMissile.java
@@ -21,8 +21,8 @@ public final class ParticleMissile extends ParticleBullet {
 	private final float proximityFuzeDistance;
 
 	//Constructor for when an entity could not be found, so a block position will be the target
-	public ParticleMissile(Point3d position, Point3d motion, ItemPart bullet, PartGun gun, IWrapperEntity gunController, Point3i target) {
-		super(position, motion, bullet, gun, gunController);
+	public ParticleMissile(Point3d position, Point3d motion, Point3d direction, ItemPart bullet, PartGun gun, IWrapperEntity gunController, Point3i target) {
+		super(position, motion, direction, bullet, gun, gunController);
 		this.targetPosition = new Point3d(target);
 		this.entityTarget = null;
 		this.anglePerTickSpeed = bullet.definition.bullet.turnFactor * 1000/bullet.definition.bullet.diameter;
@@ -31,8 +31,8 @@ public final class ParticleMissile extends ParticleBullet {
 	}
 	
 	//Passes in an entity to be used as the target
-	public ParticleMissile(Point3d position, Point3d motion, ItemPart bullet, PartGun gun, IWrapperEntity gunController, IWrapperEntity target) {
-		super(position, motion, bullet, gun, gunController);
+	public ParticleMissile(Point3d position, Point3d motion, Point3d direction, ItemPart bullet, PartGun gun, IWrapperEntity gunController, IWrapperEntity target) {
+		super(position, motion, direction, bullet, gun, gunController);
 		this.entityTarget = target;
 		this.anglePerTickSpeed = bullet.definition.bullet.turnFactor * 1000/bullet.definition.bullet.diameter;
 		this.desiredAngleOfAttack = bullet.definition.bullet.angleOfAttack;

--- a/src/main/java/minecrafttransportsimulator/vehicles/parts/PartGun.java
+++ b/src/main/java/minecrafttransportsimulator/vehicles/parts/PartGun.java
@@ -388,7 +388,8 @@ public class PartGun extends APart implements IVehiclePartFXProvider{
 			Point3d vehicleFactoredAngles = vehicle.angles.copy().add((Math.random() - 0.5F)*(10*definition.gun.diameter/(definition.gun.length*1000)), (Math.random() - 0.5F)*(10*definition.gun.diameter/(definition.gun.length*1000)), 0D);
 			
 			//Set initial velocity to the vehicle's velocity, plus the gun muzzle velocity at the specified orientation.
-			Point3d bulletVelocity = vehicle.motion.copy().multiply(vehicle.SPEED_FACTOR).add(new Point3d(0D, 0D, definition.gun.muzzleVelocity/20D/10D).rotateFine(currentOrientation).rotateFine(totalRotation).rotateFine(vehicleFactoredAngles));
+			Point3d bulletDirection = new Point3d(0D, 0D, 1D).rotateFine(currentOrientation).rotateFine(totalRotation).rotateFine(vehicleFactoredAngles);
+			Point3d bulletVelocity = vehicle.motion.copy().multiply(vehicle.SPEED_FACTOR).add(bulletDirection.multiply(definition.gun.muzzleVelocity/20D/10D));
 			
 			//Get the bullet's initial position, adjusted for barrel length and gun orientation.
 			//Then move the bullet to the appropriate firing position.
@@ -416,14 +417,14 @@ public class PartGun extends APart implements IVehiclePartFXProvider{
 				//Fire a missile with the found entity as its target, if valid
 				//Otherwise, fall back to the block target
 				if(entityTarget != null) {
-					MasterLoader.renderInterface.spawnParticle(new ParticleMissile(bulletPosition, bulletVelocity, loadedBullet, this, lastController, entityTarget));
+					MasterLoader.renderInterface.spawnParticle(new ParticleMissile(bulletPosition, bulletVelocity, bulletDirection, loadedBullet, this, lastController, entityTarget));
 				}
 				else {
-					MasterLoader.renderInterface.spawnParticle(new ParticleMissile(bulletPosition, bulletVelocity, loadedBullet, this, lastController, blockTarget));
+					MasterLoader.renderInterface.spawnParticle(new ParticleMissile(bulletPosition, bulletVelocity, bulletDirection, loadedBullet, this, lastController, blockTarget));
 				}
 			}
 			else {
-				MasterLoader.renderInterface.spawnParticle(new ParticleBullet(bulletPosition, bulletVelocity, loadedBullet, this, lastController));
+				MasterLoader.renderInterface.spawnParticle(new ParticleBullet(bulletPosition, bulletVelocity, bulletDirection, loadedBullet, this, lastController));
 			}
 			MasterLoader.audioInterface.playQuickSound(new SoundInstance(this, definition.packID + ":" + definition.systemName + "_firing"));
 			lastTimeFired = timeToFire;


### PR DESCRIPTION
Addresses #597 

The problem was essentially that if a rocket (bullet with an accelerationTime defined) was given a low enough muzzleVelocity, then vehicle motion would comprise a significant amount of its overall motion. The bugged system was applying acceleration by just multiplying the bullet motion, in some cases accelerating it backwards or sideways relative to the direction the gun was facing.

My fix was to store a unit vector of the gun's direction at the time of firing and pass this along in the bullet constructor. Then when accelerating, it would add this vector multiplied by the amount of acceleration desired. But it uses the previous calculations for missiles since they need to be able to accelerate in directions other than the initial one.