### PR TITLE
Allowed text fields to match part of a URL object

### DIFF
--- a/src/main/java/minecrafttransportsimulator/rendering/components/RenderableModelObject.java
+++ b/src/main/java/minecrafttransportsimulator/rendering/components/RenderableModelObject.java
@@ -115,7 +115,7 @@ public class RenderableModelObject<AnimationEntity extends AEntityC_Definable<?>
 					//If we don't have anything set, we just use the existing texture.
 					for(Entry<JSONText, String> textEntry : entity.text.entrySet()){
 						JSONText textDef = textEntry.getKey();
-						if(textDef.fieldName.equals(object.name)){
+						if(object.name.contains(textDef.fieldName)){
 							String textValue = entity.text.get(textDef);
 							if(!textValue.isEmpty() && !textValue.contains(" ")){
 								String errorString = InterfaceRender.downloadURLTexture(textValue);


### PR DESCRIPTION
Now a text field for URL textures can match with part of an object named with URL. 

For example, a text field named Logo_URL will give a URL to L_Logo_URL and R_Logo_URL on each door.

This is fully backward compatible.