### PR TITLE
[Minor PR] No minimum enginewearfactor and new default revlimitbounce

### DIFF
--- a/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
+++ b/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
@@ -588,7 +588,7 @@ public final class LegacyCompatSystem{
 				}
 			}
 			if(definition.engine.revlimitBounce == 0){
-				definition.engine.revlimitBounce = 8;
+				definition.engine.revlimitBounce = definition.engine.revResistance;
 			}
 			if(definition.engine.startRPM == 0){
 				definition.engine.startRPM = (int) (definition.engine.idleRPM*1.2);
@@ -603,7 +603,7 @@ public final class LegacyCompatSystem{
 			if(definition.engine.engineWinddownRate == 0){
 				definition.engine.engineWinddownRate = 10;
 			}
-			if(definition.engine.engineWearFactor <= 0.25){
+			if(definition.engine.engineWearFactor == 0){
 				definition.engine.engineWearFactor = 1;
 			}
 			if(definition.engine.coolingCoefficient == 0){


### PR DESCRIPTION
Revlimit bounce should now behave as it did when it was contained within revresistance 

~~i also resorted to this because im having trouble figuring out wheel switching on the vehicle side ):~~