### PR TITLE
Added speed_scaled

### DIFF
--- a/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
+++ b/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
@@ -760,6 +760,7 @@ public class EntityVehicleF_Physics extends AEntityVehicleE_Powered{
 			case("roll"): return angles.z;
 			case("altitude"): return position.y;
 			case("speed"): return axialVelocity*EntityVehicleF_Physics.SPEED_FACTOR*20;
+			case("speed_scaled"): return axialVelocity*20;
 			case("acceleration"): return motion.length() - prevMotion.length();
 
 			//Vehicle state cases.


### PR DESCRIPTION
speed_scaled outputs the scaled speed of the vehicle. That way sounds that should only be heard at high speed are heard more at a higher SF setting. Also eliminates the need for multiple UNU speedometers :sans: