### PR TITLE
Feature request: Add a pipeline to build (validate) the project on every commit

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,36 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: |
+          git checkout ${{ github.event.inputs.ref }}
+# Idiot github don't know how to design a pipeline at all. 
+# Why not learn from gitlab? 
+###################### Real pipeline BEGIN ####################
+      - name: Do actual things
+        run: |
+          sudo apt update ; DEBIAN_FRONTEND=noninteractive sudo apt install -y openjdk-8-jdk
+          PULL_DEPS=1 ./buildscript.sh
+      - name: Publish Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: build/libs/*.jar
+          name: Build_Result
+###################### Read pipeline END ######################
+
+

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -19,12 +19,16 @@ jobs:
           fetch-depth: 0
       - run: |
           git checkout ${{ github.event.inputs.ref }}
-# Idiot github don't know how to design a pipeline at all. 
-# Why not learn from gitlab? 
+      - name: Remove junks
+        run: |
+          # Microsoft is always messing things up behind your back. Clean them up. 
+          sudo apt update ; DEBIAN_FRONTEND=noninteractive sudo apt remove -y adoptopenjdk-11-hotspot adoptopenjdk-8-hotspot temurin-11-jdk temurin-17-jdk temurin-8-jdk openjdk-11-jre-headless
+          # Idiot microsoft don't know how to design a pipeline at all. Why not learn from gitlab? 
 ###################### Real pipeline BEGIN ####################
       - name: Do actual things
         run: |
           sudo apt update ; DEBIAN_FRONTEND=noninteractive sudo apt install -y openjdk-8-jdk
+          export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
           PULL_DEPS=1 ./buildscript.sh
       - name: Publish Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -31,6 +31,6 @@ jobs:
         with:
           path: build/libs/*.jar
           name: Build_Result
-###################### Read pipeline END ######################
+###################### Real pipeline END ######################
 
 

--- a/buildscript.sh
+++ b/buildscript.sh
@@ -15,4 +15,12 @@ echo "Configuring build.gradle for $VERPREFIX$VERSTRING"
 sed -i '19s/.*version.*/version = "'$VERPREFIX$VERSTRING'"/' build.gradle
 
 #Finally, build the mod.
-./gradlew build --offline
+if [[ "$PULL_DEPS" != 1 ]]; then
+    # Default behavior: build it with `--offline`
+    ./gradlew build --offline
+else
+    # Set PULL_DEPS=1 to build it without `--offline`
+    ./gradlew build
+fi
+
+exit $?


### PR DESCRIPTION
Benefits: 
1. If a new commit causes compilation error, we can immediately know it and fix it. 
2. If someone complains that he can not build this project, we can say "it's your problem, not ours". 
3. It automatically publishes build result for every commit. So the user can directly download the latest nightly build, and immediately try it. 