### PR TITLE
Tweaked engine variables (with some additional functionality)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ To build from source, you will need to do a few things.  These instructions assu
 <li>If you are running VSCode, run `./gradlew genVSCodeRuns`.  Then bug TurboDefender on the Discord to fill this section out.</li>
 <li>If you aren't using any of these three, START DOING SO.  Notepad is not meant for coding.  Do you want a Bad Time?  I didn't think so.</li>
 </ul>
-<li>After making your code changes, you can use Git Bash to do a `git commit -m "Message for what you commited"`. This marks the changes, and the reason for them.  Finally, do a `git push` to push the changes back up to Git.  From there, you can create a Pull Request and have your code be part of the mod!</li>
+<li>After making your code changes, use Git Bash to do a `git add -u` to add all modified files.  Then you can do a `git commit -m "Message for what you commited"`. This marks the changes, and the reason for them.  Finally, do a `git push` to push the changes back up to Git.  From there, you can create a Pull Request and have your code be part of the mod!</li>
 </ol>
 

--- a/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
+++ b/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
@@ -835,6 +835,12 @@ public class PartEngine extends APart {
             int pistonNumber = Integer.parseInt(pistonVariable.substring(0, pistonVariable.indexOf("_")));
             int totalPistons = Integer.parseInt(pistonVariable.substring(pistonVariable.indexOf("_") + 1, pistonVariable.indexOf("_", pistonVariable.indexOf("_") + 1)));
             
+            //Safety to ensure the value always fluctuates and we don't have more sectors than are possible
+            if (pistonNumber >= totalPistons) {
+            	pistonNumber = 1;
+            	totalPistons = 2;
+            }
+            
             //Map the shaft rotation to a value between 0 and 359.99...
             double shaftRotation = getEngineRotation(partialTicks) - ((360D * camMultiplier) * Math.floor(getEngineRotation(partialTicks) / (360D * camMultiplier)));
             

--- a/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
+++ b/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
@@ -836,7 +836,7 @@ public class PartEngine extends APart {
             int totalPistons = Integer.parseInt(pistonVariable.substring(pistonVariable.indexOf("_") + 1, pistonVariable.indexOf("_", pistonVariable.indexOf("_") + 1)));
             
             //Safety to ensure the value always fluctuates and we don't have more sectors than are possible
-            if (pistonNumber >= totalPistons) {
+            if (pistonNumber > totalPistons || totalPistons == 1) {
             	pistonNumber = 1;
             	totalPistons = 2;
             }

--- a/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
+++ b/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
@@ -812,6 +812,16 @@ public class PartEngine extends APart {
             case ("engine_fuelleak"):
                 return fuelLeak ? 1 : 0;
         }
+        if (variable.startsWith("engine_sin_")) {
+        	//engine_sin_X This will offset the engine rotation INPUT to the trig function by X
+            int offset = Integer.parseInt(variable.substring("engine_sin_".length()));
+        	return Math.sin(Math.toRadians(getEngineRotation(partialTicks) + offset));
+        }
+        if (variable.startsWith("engine_cos_")) {
+        	//engine_cos_X This will offset the engine rotation INPUT to the trig function by X
+            int offset = Integer.parseInt(variable.substring("engine_cos_".length()));
+        	return Math.cos(Math.toRadians(getEngineRotation(partialTicks) + offset));
+        }
         if (variable.startsWith("engine_piston_")) {
         	//Divide the crank shaft rotation into a number of sectors, and return 1 when the crank is in the defined sector.
         	//i.e. engine_piston_2_6 will return 1 when the crank is in the second of 6 sectors.

--- a/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
+++ b/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
@@ -822,6 +822,16 @@ public class PartEngine extends APart {
             int offset = Integer.parseInt(variable.substring("engine_cos_".length()));
         	return Math.cos(Math.toRadians(getEngineRotation(partialTicks) + offset));
         }
+        if (variable.startsWith("engine_driveshaft_sin_")) {
+        	//engine_driveshaft_sin_X This will offset the driveshaft rotation INPUT to the trig function by X
+            int offset = Integer.parseInt(variable.substring("engine_driveshaft_sin_".length()));
+        	return Math.sin(Math.toRadians(getDriveshaftRotation(partialTicks) + offset));
+        }
+        if (variable.startsWith("engine_driveshaft_cos_")) {
+        	//engine_driveshaft_sin_X This will offset the driveshaft rotation INPUT to the trig function by X
+            int offset = Integer.parseInt(variable.substring("engine_driveshaft_cos_".length()));
+        	return Math.cos(Math.toRadians(getDriveshaftRotation(partialTicks) + offset));
+        }
         if (variable.startsWith("engine_piston_")) {
         	//Divide the crank shaft rotation into a number of sectors, and return 1 when the crank is in the defined sector.
         	//i.e. engine_piston_2_6 will return 1 when the crank is in the second of 6 sectors.


### PR DESCRIPTION
Fixed `engine_piston` variable to be more intuitive and consistent.
Added `_cam` suffix to specify using cam rotation (two rotations of the engine).
Added the ability to offset the engine rotation input for `engine_sin` and `engine_cos` variables for more functionality.
Added the ability to offset engine_driveshaft trig variables for internal offsets as well.
Tweaked the README file to include a git step.

Wiki will be updated accordingly when pulled in.