### PR TITLE
Added Screwdriver Item

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
@@ -255,25 +255,27 @@ public abstract class APart extends AEntityF_Multipart<JSONPart> {
             return;
         }
 
-    	boolean isHoldingWrench = world.isClient() ? InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.WRENCH) : false;
-    	boolean isHoldingScrewdriver = world.isClient() ? InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.SCREWDRIVER) : false;
-
-        //If we are holding a screwdriver or wrench, run these checks to remove hitboxes if needed.
-        if (world.isClient() && (isHoldingWrench || isHoldingScrewdriver)) {
-            //If we are holding a wrench and the part requires a screwdriver, remove interaction boxes so they don't get in the way and vice versa.
-            if ((isHoldingWrench && definition.generic.mustBeRemovedByScrewdriver) || (isHoldingScrewdriver && !definition.generic.mustBeRemovedByScrewdriver)) {
-                allInteractionBoxes.removeAll(interactionBoxes);
-                return;
-            }
-            //If we are holding a wrench or screwdriver, and the part has children, don't add the interaction boxes.  We can't wrench those parts.
-            //The only exceptions are parts that have permanent-default parts on them. or if they specifically don't block subpart removal.  These can be removed.
-            //Again, this only applies on clients for that client player.
-        	for (APart childPart : parts) {
-                if (!childPart.isPermanent && !childPart.placementDefinition.allowParentRemoval) {
-                    allInteractionBoxes.removeAll(interactionBoxes);
-                    return;
-                }
-            }
+        //If we are holding a screwdriver or wrench, run these checks to remove hitboxes if needed. This can only be done on the client.
+        if (world.isClient()) {
+	    	boolean isHoldingWrench = InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.WRENCH);
+	    	boolean isHoldingScrewdriver = InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.SCREWDRIVER);
+	
+	        if (isHoldingWrench || isHoldingScrewdriver) {
+	            //If we are holding a wrench and the part requires a screwdriver, remove interaction boxes so they don't get in the way and vice versa.
+	            if ((isHoldingWrench && definition.generic.mustBeRemovedByScrewdriver) || (isHoldingScrewdriver && !definition.generic.mustBeRemovedByScrewdriver)) {
+	                allInteractionBoxes.removeAll(interactionBoxes);
+	                return;
+	            }
+	            //If we are holding a wrench or screwdriver, and the part has children, don't add the interaction boxes.  We can't wrench those parts.
+	            //The only exceptions are parts that have permanent-default parts on them. or if they specifically don't block subpart removal.  These can be removed.
+	            //Again, this only applies on clients for that client player.
+	        	for (APart childPart : parts) {
+	                if (!childPart.isPermanent && !childPart.placementDefinition.allowParentRemoval) {
+	                    allInteractionBoxes.removeAll(interactionBoxes);
+	                    return;
+	                }
+	            }
+	        }
         }
     }
 

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
@@ -255,32 +255,16 @@ public abstract class APart extends AEntityF_Multipart<JSONPart> {
             return;
         }
 
-        //If we are holding a wrench, and the part has children, don't add the interaction boxes.  We can't wrench those parts.
-        //The only exceptions are parts that have permanent-default parts on them. or if they specifically don't block subpart removal.  These can be wrenched.
-        //Again, this only applies on clients for that client player.
-        if (world.isClient() && InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.WRENCH)) {
-        	//If we are holding a screwdriver, remove the interaction boxes so they don't get in the way.
-            if (definition.generic.mustBeRemovedByScrewdriver) {
+        //If we are holding a screwdriver or wrench, run these checks to remove hitboxes if needed.
+        if (world.isClient() && (InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.WRENCH) || InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.SCREWDRIVER))) {
+            //If we are holding a wrench and the part requires a screwdriver, remove interaction boxes so they don't get in the way and vice versa.
+            if ((InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.WRENCH) && definition.generic.mustBeRemovedByScrewdriver) || (InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.SCREWDRIVER) && !definition.generic.mustBeRemovedByScrewdriver)) {
                 allInteractionBoxes.removeAll(interactionBoxes);
                 return;
             }
-            for (APart childPart : parts) {
-                if (!childPart.isPermanent && !childPart.placementDefinition.allowParentRemoval) {
-                    allInteractionBoxes.removeAll(interactionBoxes);
-                    return;
-                }
-            }
-        }
-
-        //If we are holding a screwdriver, and the part has children, don't add the interaction boxes.  We can't screwdriver those parts.
-        //The only exceptions are parts that have permanent-default parts on them. or if they specifically don't block subpart removal.  These can be screwdrivered.
-        //Again, this only applies on clients for that client player.
-        if (world.isClient() && InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.SCREWDRIVER)) {
-            //If we are holding a wrench, remove the interaction boxes so they don't get in the way.
-            if (!definition.generic.mustBeRemovedByScrewdriver) {
-                allInteractionBoxes.removeAll(interactionBoxes);
-                return;
-            }
+            //If we are holding a wrench or screwdriver, and the part has children, don't add the interaction boxes.  We can't wrench those parts.
+            //The only exceptions are parts that have permanent-default parts on them. or if they specifically don't block subpart removal.  These can be removed.
+            //Again, this only applies on clients for that client player.
         	for (APart childPart : parts) {
                 if (!childPart.isPermanent && !childPart.placementDefinition.allowParentRemoval) {
                     allInteractionBoxes.removeAll(interactionBoxes);

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
@@ -258,6 +258,9 @@ public abstract class APart extends AEntityF_Multipart<JSONPart> {
             return;
         }
 
+    	boolean isHoldingWrench = world.isClient() ? InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.WRENCH) : false;
+    	boolean isHoldingScrewdriver = world.isClient() ? InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.SCREWDRIVER) : false;
+
         //If we are holding a screwdriver or wrench, run these checks to remove hitboxes if needed.
         if (world.isClient() && (isHoldingWrench || isHoldingScrewdriver)) {
             //If we are holding a wrench and the part requires a screwdriver, remove interaction boxes so they don't get in the way and vice versa.

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
@@ -259,7 +259,29 @@ public abstract class APart extends AEntityF_Multipart<JSONPart> {
         //The only exceptions are parts that have permanent-default parts on them. or if they specifically don't block subpart removal.  These can be wrenched.
         //Again, this only applies on clients for that client player.
         if (world.isClient() && InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.WRENCH)) {
+        	//If we are holding a screwdriver, remove the interaction boxes so they don't get in the way.
+            if (definition.generic.mustBeRemovedByScrewdriver) {
+                allInteractionBoxes.removeAll(interactionBoxes);
+                return;
+            }
             for (APart childPart : parts) {
+                if (!childPart.isPermanent && !childPart.placementDefinition.allowParentRemoval) {
+                    allInteractionBoxes.removeAll(interactionBoxes);
+                    return;
+                }
+            }
+        }
+
+        //If we are holding a screwdriver, and the part has children, don't add the interaction boxes.  We can't screwdriver those parts.
+        //The only exceptions are parts that have permanent-default parts on them. or if they specifically don't block subpart removal.  These can be screwdrivered.
+        //Again, this only applies on clients for that client player.
+        if (world.isClient() && InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.SCREWDRIVER)) {
+            //If we are holding a wrench, remove the interaction boxes so they don't get in the way.
+            if (!definition.generic.mustBeRemovedByScrewdriver) {
+                allInteractionBoxes.removeAll(interactionBoxes);
+                return;
+            }
+        	for (APart childPart : parts) {
                 if (!childPart.isPermanent && !childPart.placementDefinition.allowParentRemoval) {
                     allInteractionBoxes.removeAll(interactionBoxes);
                     return;

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
@@ -246,6 +246,9 @@ public abstract class APart extends AEntityF_Multipart<JSONPart> {
 
     @Override
     protected void updateEncompassingBox() {
+    	IWrapperPlayer player = InterfaceManager.clientInterface.getClientPlayer();
+    	boolean isHoldingWrench = player.isHoldingItemType(ItemComponentType.WRENCH);
+    	boolean isHoldingScrewdriver = player.isHoldingItemType(ItemComponentType.SCREWDRIVER);
         super.updateEncompassingBox();
 
         //Don't add our interaction boxes to the box list if we aren't active and on the client.
@@ -256,9 +259,9 @@ public abstract class APart extends AEntityF_Multipart<JSONPart> {
         }
 
         //If we are holding a screwdriver or wrench, run these checks to remove hitboxes if needed.
-        if (world.isClient() && (InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.WRENCH) || InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.SCREWDRIVER))) {
+        if (world.isClient() && (isHoldingWrench || isHoldingScrewdriver)) {
             //If we are holding a wrench and the part requires a screwdriver, remove interaction boxes so they don't get in the way and vice versa.
-            if ((InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.WRENCH) && definition.generic.mustBeRemovedByScrewdriver) || (InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.SCREWDRIVER) && !definition.generic.mustBeRemovedByScrewdriver)) {
+            if ((isHoldingWrench && definition.generic.mustBeRemovedByScrewdriver) || (isHoldingScrewdriver && !definition.generic.mustBeRemovedByScrewdriver)) {
                 allInteractionBoxes.removeAll(interactionBoxes);
                 return;
             }

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
@@ -246,9 +246,6 @@ public abstract class APart extends AEntityF_Multipart<JSONPart> {
 
     @Override
     protected void updateEncompassingBox() {
-    	IWrapperPlayer player = InterfaceManager.clientInterface.getClientPlayer();
-    	boolean isHoldingWrench = player.isHoldingItemType(ItemComponentType.WRENCH);
-    	boolean isHoldingScrewdriver = player.isHoldingItemType(ItemComponentType.SCREWDRIVER);
         super.updateEncompassingBox();
 
         //Don't add our interaction boxes to the box list if we aren't active and on the client.

--- a/mccore/src/main/java/minecrafttransportsimulator/items/instances/ItemItem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/items/instances/ItemItem.java
@@ -60,7 +60,8 @@ public class ItemItem extends AItemPack<JSONItem> implements IItemEntityInteract
     @Override
     public CallbackType doEntityInteraction(AEntityE_Interactable<?> entity, BoundingBox hitBox, IWrapperPlayer player, PlayerOwnerState ownerState, boolean rightClick) {
         switch (definition.item.type) {
-	        case WRENCH: {
+	        case WRENCH: 
+	        case SCREWDRIVER: {
 	            if (!entity.world.isClient()) {
 	                //If the player isn't the owner of the entity, they can't interact with it.
 	                if (!ownerState.equals(PlayerOwnerState.USER)) {
@@ -97,42 +98,7 @@ public class ItemItem extends AItemPack<JSONItem> implements IItemEntityInteract
 	                        }else {
 	                            if (entity instanceof APart) {
 	                                APart part = (APart) entity;
-	                                if (!part.isPermanent && part.isValid && !part.definition.generic.mustBeRemovedByScrewdriver) {
-	                                    LanguageEntry partResult = part.checkForRemoval();
-	                                    if (partResult != null) {
-	                                        player.sendPacket(new PacketPlayerChatMessage(player, partResult));
-	                                        return CallbackType.NONE;
-	                                    } else {
-	                                        //Player can remove part, spawn item in the world and remove part.
-	                                        AItemPart droppedItem = part.getItem();
-	                                        if (droppedItem != null) {
-	                                            part.entityOn.world.spawnItem(droppedItem, part.save(InterfaceManager.coreInterface.getNewNBTWrapper()), part.position);
-	                                        }
-	                                        part.entityOn.removePart(part, null);
-	                                    }
-	                                }
-	                            }
-	                        }
-	                    }
-	                } else {
-	                    player.sendPacket(new PacketPlayerChatMessage(player, JSONConfigLanguage.INTERACT_VEHICLE_OWNED));
-	                }
-	            }
-	            return CallbackType.NONE;
-	        }
-	        case SCREWDRIVER: {
-	            if (!entity.world.isClient()) {
-	                //If the player isn't the owner of the entity, they can't interact with it.
-	                if (!ownerState.equals(PlayerOwnerState.USER)) {
-	                    if (rightClick) {
-	                        //Right-clicking
-	                    } else {
-	                        //Left clicking removes parts, or X, if we were sneaking.
-	                        if(player.isSneaking()) {
-	                        }else {
-	                            if (entity instanceof APart) {
-	                                APart part = (APart) entity;
-	                                if (!part.isPermanent && part.isValid && part.definition.generic.mustBeRemovedByScrewdriver) {
+	                                if (!part.isPermanent && part.isValid) {
 	                                    LanguageEntry partResult = part.checkForRemoval();
 	                                    if (partResult != null) {
 	                                        player.sendPacket(new PacketPlayerChatMessage(player, partResult));

--- a/mccore/src/main/java/minecrafttransportsimulator/items/instances/ItemItem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/items/instances/ItemItem.java
@@ -60,101 +60,101 @@ public class ItemItem extends AItemPack<JSONItem> implements IItemEntityInteract
     @Override
     public CallbackType doEntityInteraction(AEntityE_Interactable<?> entity, BoundingBox hitBox, IWrapperPlayer player, PlayerOwnerState ownerState, boolean rightClick) {
         switch (definition.item.type) {
-        case WRENCH: {
-            if (!entity.world.isClient()) {
-                //If the player isn't the owner of the entity, they can't interact with it.
-                if (!ownerState.equals(PlayerOwnerState.USER)) {
-                    if (rightClick) {
-                        //Right-clicking opens GUIs.
-                        if (entity instanceof EntityVehicleF_Physics) {
-                            EntityVehicleF_Physics vehicle = (EntityVehicleF_Physics) entity;
-                            if (ConfigSystem.settings.general.devMode.value && vehicle.allParts.contains(player.getEntityRiding())) {
-                                player.sendPacket(new PacketEntityGUIRequest(vehicle, player, PacketEntityGUIRequest.EntityGUIType.PACK_EXPORTER));
-                            } else {
-                                player.sendPacket(new PacketEntityGUIRequest(vehicle, player, PacketEntityGUIRequest.EntityGUIType.INSTRUMENTS));
-                            }
-                        } else if (player.isSneaking()) {
-                            player.sendPacket(new PacketEntityGUIRequest(entity, player, PacketEntityGUIRequest.EntityGUIType.TEXT_EDITOR));
-                        }
-                    } else {
-                        //Left clicking removes parts, or removes vehicles, if we were sneaking.
-                        if(player.isSneaking()) {
-                            EntityVehicleF_Physics vehicle;
-                            if(entity instanceof APart) {
-                                vehicle = ((APart) entity).vehicleOn;
-                            }else if(entity instanceof EntityVehicleF_Physics) {
-                                vehicle = (EntityVehicleF_Physics) entity;
-                            } else {
-                                vehicle = null;
-                            }
-                            if(vehicle != null) {
-                                if ((!ConfigSystem.settings.general.opPickupVehiclesOnly.value || ownerState.equals(PlayerOwnerState.ADMIN)) && (!ConfigSystem.settings.general.creativePickupVehiclesOnly.value || player.isCreative()) && entity.isValid) {
-                                    vehicle.disconnectAllConnections();
-                                    vehicle.world.spawnItem(vehicle.getItem(), vehicle.save(InterfaceManager.coreInterface.getNewNBTWrapper()), hitBox.globalCenter);
-                                    vehicle.remove();
-                                }
-                            }
-                        }else {
-                            if (entity instanceof APart) {
-                                APart part = (APart) entity;
-                                if (!part.isPermanent && part.isValid && !part.definition.generic.mustBeRemovedByScrewdriver) {
-                                    LanguageEntry partResult = part.checkForRemoval();
-                                    if (partResult != null) {
-                                        player.sendPacket(new PacketPlayerChatMessage(player, partResult));
-                                        return CallbackType.NONE;
-                                    } else {
-                                        //Player can remove part, spawn item in the world and remove part.
-                                        AItemPart droppedItem = part.getItem();
-                                        if (droppedItem != null) {
-                                            part.entityOn.world.spawnItem(droppedItem, part.save(InterfaceManager.coreInterface.getNewNBTWrapper()), part.position);
-                                        }
-                                        part.entityOn.removePart(part, null);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    player.sendPacket(new PacketPlayerChatMessage(player, JSONConfigLanguage.INTERACT_VEHICLE_OWNED));
-                }
-            }
-            return CallbackType.NONE;
-        }
-        case SCREWDRIVER: {
-            if (!entity.world.isClient()) {
-                //If the player isn't the owner of the entity, they can't interact with it.
-                if (!ownerState.equals(PlayerOwnerState.USER)) {
-                    if (rightClick) {
-                        //Right-clicking
-                    } else {
-                        //Left clicking removes parts, or X, if we were sneaking.
-                        if(player.isSneaking()) {
-                        }else {
-                            if (entity instanceof APart) {
-                                APart part = (APart) entity;
-                                if (!part.isPermanent && part.isValid && part.definition.generic.mustBeRemovedByScrewdriver) {
-                                    LanguageEntry partResult = part.checkForRemoval();
-                                    if (partResult != null) {
-                                        player.sendPacket(new PacketPlayerChatMessage(player, partResult));
-                                        return CallbackType.NONE;
-                                    } else {
-                                        //Player can remove part, spawn item in the world and remove part.
-                                        AItemPart droppedItem = part.getItem();
-                                        if (droppedItem != null) {
-                                            part.entityOn.world.spawnItem(droppedItem, part.save(InterfaceManager.coreInterface.getNewNBTWrapper()), part.position);
-                                        }
-                                        part.entityOn.removePart(part, null);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    player.sendPacket(new PacketPlayerChatMessage(player, JSONConfigLanguage.INTERACT_VEHICLE_OWNED));
-                }
-            }
-            return CallbackType.NONE;
-        }
+	        case WRENCH: {
+	            if (!entity.world.isClient()) {
+	                //If the player isn't the owner of the entity, they can't interact with it.
+	                if (!ownerState.equals(PlayerOwnerState.USER)) {
+	                    if (rightClick) {
+	                        //Right-clicking opens GUIs.
+	                        if (entity instanceof EntityVehicleF_Physics) {
+	                            EntityVehicleF_Physics vehicle = (EntityVehicleF_Physics) entity;
+	                            if (ConfigSystem.settings.general.devMode.value && vehicle.allParts.contains(player.getEntityRiding())) {
+	                                player.sendPacket(new PacketEntityGUIRequest(vehicle, player, PacketEntityGUIRequest.EntityGUIType.PACK_EXPORTER));
+	                            } else {
+	                                player.sendPacket(new PacketEntityGUIRequest(vehicle, player, PacketEntityGUIRequest.EntityGUIType.INSTRUMENTS));
+	                            }
+	                        } else if (player.isSneaking()) {
+	                            player.sendPacket(new PacketEntityGUIRequest(entity, player, PacketEntityGUIRequest.EntityGUIType.TEXT_EDITOR));
+	                        }
+	                    } else {
+	                        //Left clicking removes parts, or removes vehicles, if we were sneaking.
+	                        if(player.isSneaking()) {
+	                            EntityVehicleF_Physics vehicle;
+	                            if(entity instanceof APart) {
+	                                vehicle = ((APart) entity).vehicleOn;
+	                            }else if(entity instanceof EntityVehicleF_Physics) {
+	                                vehicle = (EntityVehicleF_Physics) entity;
+	                            } else {
+	                                vehicle = null;
+	                            }
+	                            if(vehicle != null) {
+	                                if ((!ConfigSystem.settings.general.opPickupVehiclesOnly.value || ownerState.equals(PlayerOwnerState.ADMIN)) && (!ConfigSystem.settings.general.creativePickupVehiclesOnly.value || player.isCreative()) && entity.isValid) {
+	                                    vehicle.disconnectAllConnections();
+	                                    vehicle.world.spawnItem(vehicle.getItem(), vehicle.save(InterfaceManager.coreInterface.getNewNBTWrapper()), hitBox.globalCenter);
+	                                    vehicle.remove();
+	                                }
+	                            }
+	                        }else {
+	                            if (entity instanceof APart) {
+	                                APart part = (APart) entity;
+	                                if (!part.isPermanent && part.isValid && !part.definition.generic.mustBeRemovedByScrewdriver) {
+	                                    LanguageEntry partResult = part.checkForRemoval();
+	                                    if (partResult != null) {
+	                                        player.sendPacket(new PacketPlayerChatMessage(player, partResult));
+	                                        return CallbackType.NONE;
+	                                    } else {
+	                                        //Player can remove part, spawn item in the world and remove part.
+	                                        AItemPart droppedItem = part.getItem();
+	                                        if (droppedItem != null) {
+	                                            part.entityOn.world.spawnItem(droppedItem, part.save(InterfaceManager.coreInterface.getNewNBTWrapper()), part.position);
+	                                        }
+	                                        part.entityOn.removePart(part, null);
+	                                    }
+	                                }
+	                            }
+	                        }
+	                    }
+	                } else {
+	                    player.sendPacket(new PacketPlayerChatMessage(player, JSONConfigLanguage.INTERACT_VEHICLE_OWNED));
+	                }
+	            }
+	            return CallbackType.NONE;
+	        }
+	        case SCREWDRIVER: {
+	            if (!entity.world.isClient()) {
+	                //If the player isn't the owner of the entity, they can't interact with it.
+	                if (!ownerState.equals(PlayerOwnerState.USER)) {
+	                    if (rightClick) {
+	                        //Right-clicking
+	                    } else {
+	                        //Left clicking removes parts, or X, if we were sneaking.
+	                        if(player.isSneaking()) {
+	                        }else {
+	                            if (entity instanceof APart) {
+	                                APart part = (APart) entity;
+	                                if (!part.isPermanent && part.isValid && part.definition.generic.mustBeRemovedByScrewdriver) {
+	                                    LanguageEntry partResult = part.checkForRemoval();
+	                                    if (partResult != null) {
+	                                        player.sendPacket(new PacketPlayerChatMessage(player, partResult));
+	                                        return CallbackType.NONE;
+	                                    } else {
+	                                        //Player can remove part, spawn item in the world and remove part.
+	                                        AItemPart droppedItem = part.getItem();
+	                                        if (droppedItem != null) {
+	                                            part.entityOn.world.spawnItem(droppedItem, part.save(InterfaceManager.coreInterface.getNewNBTWrapper()), part.position);
+	                                        }
+	                                        part.entityOn.removePart(part, null);
+	                                    }
+	                                }
+	                            }
+	                        }
+	                    }
+	                } else {
+	                    player.sendPacket(new PacketPlayerChatMessage(player, JSONConfigLanguage.INTERACT_VEHICLE_OWNED));
+	                }
+	            }
+	            return CallbackType.NONE;
+	        }
             case PAINT_GUN: {
                 if (!entity.world.isClient() && rightClick) {
                     //If the player isn't the owner of the entity, they can't interact with it.
@@ -348,7 +348,7 @@ public class ItemItem extends AItemPack<JSONItem> implements IItemEntityInteract
                 return CallbackType.NONE;
             }
             default:
-                return CallbackType.SKIP;
+            return CallbackType.SKIP;
         }
     }
 

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONItem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONItem.java
@@ -97,6 +97,8 @@ public class JSONItem extends AJSONItem {
         SCANNER,
         @JSONDescription("Creates an item that works as a wrench.")
         WRENCH,
+        @JSONDescription("Creates an item that works as a screwdriver.")
+        SCREWDRIVER,
         @JSONDescription("Creates an item that works as a paint gun.")
         PAINT_GUN,
         @JSONDescription("Creates an item that works as a key.")

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
@@ -93,7 +93,7 @@ public class JSONPart extends AJSONPartProvider {
         @JSONDescription("If true, this part will be able to be removed by hand and without a wrench.  This also bypasses owner requirements (but not vehicle locking).  Useful for small parts like luggage that anyone should be able to remove at any time.")
         public boolean canBeRemovedByHand;
 
-        @JSONDescription("If true, this part will be able to be removed by hand and without a wrench.  This also bypasses owner requirements (but not vehicle locking).  Useful for small parts like luggage that anyone should be able to remove at any time.")
+        @JSONDescription("If true, this item can only be removed with a Screwdriver item, not a wrench.")
         public boolean mustBeRemovedByScrewdriver;
 
         @JSONDescription("If true, this part will forward damage onto the vehicle it is on when hit by a bullet.  This will also cause the bullet to stop when it hits this part.  Engines ignore this behavior and always forward damage.")

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
@@ -93,6 +93,9 @@ public class JSONPart extends AJSONPartProvider {
         @JSONDescription("If true, this part will be able to be removed by hand and without a wrench.  This also bypasses owner requirements (but not vehicle locking).  Useful for small parts like luggage that anyone should be able to remove at any time.")
         public boolean canBeRemovedByHand;
 
+        @JSONDescription("If true, this part will be able to be removed by hand and without a wrench.  This also bypasses owner requirements (but not vehicle locking).  Useful for small parts like luggage that anyone should be able to remove at any time.")
+        public boolean mustBeRemovedByScrewdriver;
+
         @JSONDescription("If true, this part will forward damage onto the vehicle it is on when hit by a bullet.  This will also cause the bullet to stop when it hits this part.  Engines ignore this behavior and always forward damage.")
         public boolean forwardsDamage;
 


### PR DESCRIPTION
A Screwdriver is simply a mutually exclusive wrench that can only remove parts tagged with `mustBeRemovedByScrewdriver` in their generic section. Wrenches will ignore these parts.

Perfect for things like hubcaps where you may want to remove the wheel as an assembly when paired with `allowParentRemoval`.

This _should_ add a screwdriver item to the MTS core mod. It's even red!

Currently wrenches ONLY remove parts. They have no other functionality like a wrench does, but they could in the future.