### PR TITLE
Fixed a bug with conditionalDefaultParts

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityF_Multipart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityF_Multipart.java
@@ -429,9 +429,6 @@ public abstract class AEntityF_Multipart<JSONDefinition extends AJSONPartProvide
                 //We also need to know if it is a new part or not, since that allows non-permanent default parts to be added.
                 JSONPartDefinition partDef = definition.parts.get(i);
                 if (newEntity) {
-                    if (partDef.defaultPart != null) {
-                        addDefaultPart(partDef.defaultPart, i, placingPlayer, definition);
-                    }
                     if (partDef.conditionalDefaultParts != null) {
                         //Add constants. This is also done in initializeAnimations, but repeating it here ensures 
                     	//the value will be set before spawning in any conditional parts.
@@ -446,6 +443,9 @@ public abstract class AEntityF_Multipart<JSONDefinition extends AJSONPartProvide
                                 break;
                             }
                         }
+                    }
+                    if (partDef.defaultPart != null) {
+                        addDefaultPart(partDef.defaultPart, i, placingPlayer, definition);
                     }
                 }
             }

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityF_Multipart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityF_Multipart.java
@@ -433,6 +433,13 @@ public abstract class AEntityF_Multipart<JSONDefinition extends AJSONPartProvide
                         addDefaultPart(partDef.defaultPart, i, placingPlayer, definition);
                     }
                     if (partDef.conditionalDefaultParts != null) {
+                        //Add constants. This is also done in initializeAnimations, but repeating it here ensures 
+                    	//the value will be set before spawning in any conditional parts.
+                        if (definition.rendering != null && definition.rendering.constants != null) {
+                            for (String variable : definition.rendering.constants) {
+                                variables.put(variable, 1D);
+                            }
+                        }
                         for (Entry<String, String> conditionalDef : partDef.conditionalDefaultParts.entrySet()) {
                             if (getRawVariableValue(conditionalDef.getKey(), 0) > 0) {
                                 addDefaultPart(conditionalDef.getValue(), i, placingPlayer, definition);


### PR DESCRIPTION
Fixed the bug where upon initial placement the part would not be present if the variable was defined in the rendering constants section, as opposed to the definitions constant section.

This repeats the setting the constants, but that is needed since this only executes when there is a conditional default part on a new entity.