### PR TITLE
Vairables for guided weapons

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/baseclasses/EntityManager.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/baseclasses/EntityManager.java
@@ -6,7 +6,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import minecrafttransportsimulator.entities.components.AEntityA_Base;
 import minecrafttransportsimulator.entities.components.AEntityC_Renderable;
-import minecrafttransportsimulator.entities.components.AEntityE_Interactable;
 
 /**
  * Class that manages entities in a world or other area.
@@ -64,43 +63,6 @@ public class EntityManager {
             entitiesByClass.put(entityClass, classListing);
         }
         return classListing;
-    }
-
-    /**
-     * Returns the closest entity of the specified class that intersects the ray-traced line,
-     * or null if none does. This up-scales the entity Bounding Boxes to
-     * allow for a somewhat easier targeting scheme if generalArea is true.
-     */
-    public <EntityType extends AEntityE_Interactable<?>> EntityType getRaytraced(Class<EntityType> entityClass, Point3D start, Point3D end, boolean generalArea, EntityType entityToIgnore) {
-        BoundingBox closestBox = null;
-        EntityType closestEntity = null;
-        BoundingBox clickBounds = new BoundingBox(start, end);
-        for (EntityType entity : getEntitiesOfType(entityClass)) {
-            if (!entity.equals(entityToIgnore) && entity.encompassingBox.intersects(clickBounds)) {
-                //Could have hit this entity, check if we did via raytracing.
-                for (BoundingBox box : entity.getInteractionBoxes()) {
-                    boolean intersects;
-                    if (generalArea) {
-                        box.widthRadius += 2;
-                        box.heightRadius += 2;
-                        box.depthRadius += 2;
-                        intersects = box.intersects(clickBounds) && box.getIntersectionPoint(start, end) != null;
-                        box.widthRadius -= 2;
-                        box.heightRadius -= 2;
-                        box.depthRadius -= 2;
-                    } else {
-                        intersects = box.intersects(clickBounds) && box.getIntersectionPoint(start, end) != null;
-                    }
-                    if (intersects) {
-                        if (closestBox == null || start.isFirstCloserThanSecond(box.globalCenter, closestBox.globalCenter)) {
-                            closestBox = box;
-                            closestEntity = entity;
-                        }
-                    }
-                }
-            }
-        }
-        return closestEntity;
     }
 
     /**

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
@@ -802,13 +802,13 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
                         case ("distance"):
                             return contact.position.distanceTo(position);
                         case ("direction"):
-                            return Math.toDegrees(Math.atan2(-contact.position.z + position.z, -contact.position.x + position.x)) + 90 + orientation.angles.y;
+                            return Math.toDegrees(Math.atan2(-contact.position.z + position.z, -contact.position.x + position.x)) + 90;
                         case ("speed"):
                             return contact.velocity;
                         case ("altitude"):
                             return contact.position.y;
                         case ("angle"):
-                            return Math.toDegrees(Math.atan2(-contact.position.y + position.y,-contact.position.z + position.z)) + orientation.angles.x;
+                            return -Math.toDegrees(Math.atan2(-contact.position.y + position.y,Math.hypot(-contact.position.z + position.z,-contact.position.x + position.x))) + orientation.angles.x;
                     }
                 }
             }

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
@@ -807,6 +807,8 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
                             return contact.velocity;
                         case ("altitude"):
                             return contact.position.y;
+                        case ("angle"):
+                            return Math.toDegrees(Math.atan2(-contact.position.y + position.y,-contact.position.z + position.z)) + orientation.angles.x;
                     }
                 }
             }

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
@@ -802,7 +802,7 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
                         case ("distance"):
                             return contact.position.distanceTo(position);
                         case ("direction"):
-                            return Math.toDegrees(Math.atan2(-contact.position.z + position.z, -contact.position.x + position.x)) + 90;
+                            return Math.toDegrees(Math.atan2(-contact.position.z + position.z, -contact.position.x + position.x)) + 90 + orientation.angles.y;
                         case ("speed"):
                             return contact.velocity;
                         case ("altitude"):

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
@@ -801,6 +801,8 @@ public class EntityVehicleF_Physics extends AEntityVehicleE_Powered {
                 return ((rotation.angles.z) / 10 + rotation.angles.y) / 0.15D * 25;
             case ("turn_indicator"):
                 return (rotation.angles.y) / 0.15F * 25F;
+            case ("pitch_indicator"):
+                return (rotation.angles.x) / 0.15F * 25F;
             case ("slip"):
                 return 75 * sideVector.dotProduct(normalizedVelocityVector, true);
             case ("gear_moving"):

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
@@ -622,7 +622,7 @@ public class PartGun extends APart {
                             }
                         }
                         //Locks only onto aircraft
-                    } else if (definition.gun.targetTypes != null && !definition.gun.targetTypes.contains(TargetTypes.ALL) && definition.gun.targetTypes.contains(TargetTypes.AIRCRAFT)) {
+                    } else if (!definition.gun.targetTypes.contains(TargetTypes.ALL) && definition.gun.targetTypes.contains(TargetTypes.AIRCRAFT)) {
                         if (entityTarget == null) {
                             engineTarget = null;
                             EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
@@ -638,7 +638,7 @@ public class PartGun extends APart {
                             }
                         }
                         //Locks only onto ground vehicles
-                    } else if (definition.gun.targetTypes != null && !definition.gun.targetTypes.contains(TargetTypes.ALL) && definition.gun.targetTypes.contains(TargetTypes.GROUND)) {
+                    } else if (!definition.gun.targetTypes.contains(TargetTypes.ALL) && definition.gun.targetTypes.contains(TargetTypes.GROUND)) {
                         if (entityTarget == null) {
                             engineTarget = null;
                             EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
@@ -654,7 +654,7 @@ public class PartGun extends APart {
                             }
                         }
                         //Locks only onto players or mobs. "soft targets"
-                    } else if (definition.gun.targetTypes != null && !definition.gun.targetTypes.contains(TargetTypes.ALL) && definition.gun.targetTypes.contains(TargetTypes.SOFT)) {
+                    } else if (!definition.gun.targetTypes.contains(TargetTypes.ALL) && definition.gun.targetTypes.contains(TargetTypes.SOFT)) {
                         entityTarget = world.getEntityLookingAt(controller, RAYTRACE_DISTANCE, true);
                     }
                 }

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
@@ -601,21 +601,64 @@ public class PartGun extends APart {
             //Player-controlled gun.
             //Check for a target for this gun if we have a lock-on missile.
             //Only do this once every 1/2 second.
+            //First, check if this bullet is guided
             if (loadedBullet != null && loadedBullet.definition.bullet.turnRate > 0) {
-                //Try to find the entity the controller is looking at.
-                entityTarget = world.getEntityLookingAt(controller, RAYTRACE_DISTANCE, true);
-                if (entityTarget == null) {
-                    engineTarget = null;
-                    EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
-                    if (vehicleTargeted != null) {
-                        for (APart part : vehicleTargeted.parts) {
-                            if (part instanceof PartEngine) {
-                                engineTarget = (PartEngine) part;
-                                break;
+                //New lock on logic. Determines if it can lock a target
+                //Default old method of lokking at it to lock. Still has its uses for realistic instances.
+                if ((definition.gun.lockOnType == null || definition.gun.lockOnType == LockOnType.DEFAULT) ) {
+                    //check for valid target type. By default it lock any entity.
+                    if (definition.gun.targetTypes == null || definition.gun.targetTypes.contains(TargetTypes.ALL)) {
+                        entityTarget = world.getEntityLookingAt(controller, RAYTRACE_DISTANCE, true);
+                        if (entityTarget == null) {
+                            engineTarget = null;
+                            EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
+                            if (vehicleTargeted != null && !vehicleTargeted.outOfHealth) {
+                                for (APart part : vehicleTargeted.parts) {
+                                    if (part instanceof PartEngine) {
+                                        engineTarget = (PartEngine) part;
+                                        break;
+                                    }
+                                }
                             }
                         }
+                        //Locks only onto aircraft
+                    } else if (definition.gun.targetTypes != null && !definition.gun.targetTypes.contains(TargetTypes.ALL) && definition.gun.targetTypes.contains(TargetTypes.AIRCRAFT)) {
+                        if (entityTarget == null) {
+                            engineTarget = null;
+                            EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
+                            if (vehicleTargeted != null) {
+                                if (vehicleTargeted.definition.motorized.isAircraft) {
+                                    for (APart part : vehicleTargeted.parts) {
+                                        if (part instanceof PartEngine) {
+                                            engineTarget = (PartEngine) part;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        //Locks only onto ground vehicles
+                    } else if (definition.gun.targetTypes != null && !definition.gun.targetTypes.contains(TargetTypes.ALL) && definition.gun.targetTypes.contains(TargetTypes.GROUND)) {
+                        if (entityTarget == null) {
+                            engineTarget = null;
+                            EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
+                            if (vehicleTargeted != null) {
+                                if (!vehicleTargeted.definition.motorized.isAircraft) {
+                                    for (APart part : vehicleTargeted.parts) {
+                                        if (part instanceof PartEngine) {
+                                            engineTarget = (PartEngine) part;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        //Locks only onto players or mobs. "soft targets"
+                    } else if (definition.gun.targetTypes != null && !definition.gun.targetTypes.contains(TargetTypes.ALL) && definition.gun.targetTypes.contains(TargetTypes.SOFT)) {
+                        entityTarget = world.getEntityLookingAt(controller, RAYTRACE_DISTANCE, true);
                     }
                 }
+
             }
 
             //If we are holding the trigger, request to fire.

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
@@ -623,6 +623,7 @@ public class PartGun extends APart {
                                 break;
                             }
                             case AIRCRAFT:{
+                                engineTarget = null;
                                 EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
                                 if (vehicleTargeted != null && !vehicleTargeted.outOfHealth && vehicleTargeted.definition.motorized.isAircraft) {
                                     for (APart part : vehicleTargeted.parts) {
@@ -635,6 +636,7 @@ public class PartGun extends APart {
                                 break;
                             }
                             case GROUND:{
+                                engineTarget = null;
                                 EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
                                 if (vehicleTargeted != null && !vehicleTargeted.outOfHealth && !vehicleTargeted.definition.motorized.isAircraft) {
                                     for (APart part : vehicleTargeted.parts) {
@@ -647,6 +649,7 @@ public class PartGun extends APart {
                                 break;
                             }
                             case HARD:{
+                                engineTarget = null;
                                 EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
                                 if (vehicleTargeted != null && !vehicleTargeted.outOfHealth) {
                                     for (APart part : vehicleTargeted.parts) {

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
@@ -603,69 +603,114 @@ public class PartGun extends APart {
             //Only do this once every 1/2 second.
             //First, check if the loaded bullet is guided
             if (loadedBullet != null && loadedBullet.definition.bullet.turnRate > 0) {
-                //New lock on logic. Determines if it can lock a target
-                //Default old method of looking at it to lock. Still has its uses for realistic instances.
-                if ((definition.gun.lockOnType == null || definition.gun.lockOnType == LockOnType.DEFAULT) ) {
-                    //check for valid target type. By default it locks any entity.
-                    if (definition.gun.targetType == TargetType.ALL) {
-                        entityTarget = world.getEntityLookingAt(controller, RAYTRACE_DISTANCE, true);
-                        if (entityTarget == null) {
-                            engineTarget = null;
-                            EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
-                            if (vehicleTargeted != null && !vehicleTargeted.outOfHealth) {
-                                for (APart part : vehicleTargeted.parts) {
-                                    if (part instanceof PartEngine) {
-                                        engineTarget = (PartEngine) part;
-                                        break;
+                switch (definition.gun.lockOnType) {
+                    case DEFAULT:{
+                        switch (definition.gun.targetType) {
+                            case ALL:{
+                                entityTarget = world.getEntityLookingAt(controller, RAYTRACE_DISTANCE, true);
+                                if (entityTarget == null) {
+                                    engineTarget = null;
+                                    EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
+                                    if (vehicleTargeted != null && !vehicleTargeted.outOfHealth) {
+                                        for (APart part : vehicleTargeted.parts) {
+                                            if (part instanceof PartEngine) {
+                                                engineTarget = (PartEngine) part;
+                                                break;
+                                            }
+                                        }
                                     }
                                 }
+                                break;
                             }
-                        }
-                        //Locks only onto aircraft
-                    } else if (definition.gun.targetType == TargetType.AIRCRAFT) {
-                        if (entityTarget == null) {
-                            engineTarget = null;
-                            EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
-                            if (vehicleTargeted != null && !vehicleTargeted.outOfHealth && vehicleTargeted.definition.motorized.isAircraft) {
-                                for (APart part : vehicleTargeted.parts) {
-                                    if (part instanceof PartEngine) {
-                                        engineTarget = (PartEngine) part;
-                                        break;
+                            case AIRCRAFT:{
+                                EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
+                                if (vehicleTargeted != null && !vehicleTargeted.outOfHealth && vehicleTargeted.definition.motorized.isAircraft) {
+                                    for (APart part : vehicleTargeted.parts) {
+                                        if (part instanceof PartEngine) {
+                                            engineTarget = (PartEngine) part;
+                                            break;
+                                        }
                                     }
                                 }
+                                break;
                             }
-                        }
-                        //Locks only onto ground vehicles
-                    } else if (definition.gun.targetType == TargetType.GROUND) {
-                        if (entityTarget == null) {
-                            engineTarget = null;
-                            EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
-                            if (vehicleTargeted != null && !vehicleTargeted.outOfHealth && !vehicleTargeted.definition.motorized.isAircraft) {
-                                for (APart part : vehicleTargeted.parts) {
-                                    if (part instanceof PartEngine) {
-                                        engineTarget = (PartEngine) part;
-                                        break;
+                            case GROUND:{
+                                EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
+                                if (vehicleTargeted != null && !vehicleTargeted.outOfHealth && !vehicleTargeted.definition.motorized.isAircraft) {
+                                    for (APart part : vehicleTargeted.parts) {
+                                        if (part instanceof PartEngine) {
+                                            engineTarget = (PartEngine) part;
+                                            break;
+                                        }
                                     }
                                 }
+                                break;
                             }
-                        }
-                        //Locks only onto players or mobs. "soft targets"
-                    } else if (definition.gun.targetType == TargetType.HARD) {
-                        if (entityTarget == null) {
-                            engineTarget = null;
-                            EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
-                            if (vehicleTargeted != null && !vehicleTargeted.outOfHealth) {
-                                for (APart part : vehicleTargeted.parts) {
-                                    if (part instanceof PartEngine) {
-                                        engineTarget = (PartEngine) part;
-                                        break;
+                            case HARD:{
+                                EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
+                                if (vehicleTargeted != null && !vehicleTargeted.outOfHealth) {
+                                    for (APart part : vehicleTargeted.parts) {
+                                        if (part instanceof PartEngine) {
+                                            engineTarget = (PartEngine) part;
+                                            break;
+                                        }
                                     }
                                 }
+                                break;
+                            }
+                            case SOFT:{
+                                entityTarget = world.getEntityLookingAt(controller, RAYTRACE_DISTANCE, true);
+                                break;
                             }
                         }
-                        //Locks onto either ground or air vehicles.
-                    } else if (definition.gun.targetType == TargetType.SOFT) {
-                        entityTarget = world.getEntityLookingAt(controller, RAYTRACE_DISTANCE, true);
+                        break;
+                    }
+                    case BORESIGHT:{
+                        //Sees the closest target within a specified range and angle in front of the gun itself
+                        //rather than what the player looks at.
+                        switch (definition.gun.targetType) {
+                            case ALL: {
+                                break;
+                            }
+                            case AIRCRAFT: {
+                                break;
+                            }
+                            case GROUND: {
+                                break;
+                            }
+                            case HARD: {
+                                break;
+                            }
+                            case SOFT: {
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                    case RADAR:{
+                        //select a specific target and lock the vehicle entity itself rather than the engine.
+                        switch (definition.gun.targetType) {
+                            case ALL: {
+                                break;
+                            }
+                            case AIRCRAFT: {
+                                break;
+                            }
+                            case GROUND: {
+                                break;
+                            }
+                            case HARD: {
+                                break;
+                            }
+                            case SOFT: {
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                    case MANUAL:{
+                        //laser guidance. Just goes where the player or camera is pointed.
+                        break;
                     }
                 }
             }

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
@@ -679,18 +679,21 @@ public class PartGun extends APart {
                             case AIRCRAFT: {
                                 Point3D gunLookVec = new Point3D(0,0,1).rotate(orientation);
                                 EntityVehicleF_Physics closestVehicle;
-                                IWrapperEntity closestMob;
+                                EntityVehicleF_Physics closestTarget;
                                 double minDist = definition.gun.lockRange;
                                 for (EntityVehicleF_Physics ivEntity : world.getEntitiesOfType(EntityVehicleF_Physics.class)) {
                                     Point3D vecToTarget = ivEntity.position.copy().subtract(position).normalize();
                                     double targetAngle = Math.abs(Math.toDegrees(Math.acos(vecToTarget.dotProduct(gunLookVec, false))));
                                     double dist = ivEntity.position.distanceTo(position);
-                                    if (!ivEntity.isValid || ivEntity.outOfHealth || targetAngle > definition.gun.lockMaxAngle || dist > minDist || ivEntity == this.entityOn || !ivEntity.definition.motorized.isAircraft) {
+                                    if (!ivEntity.isValid || targetAngle > definition.gun.lockMaxAngle || dist > minDist || ivEntity == this.entityOn || !ivEntity.definition.motorized.isAircraft) {
                                         engineTarget = null;
                                     } else {
                                         closestVehicle = ivEntity;
+                                    }
+                                    if (closestVehicle != null && !closestVehicle.outOfHealth) {
                                         minDist = dist;
-                                        for (APart part : closestVehicle.parts) {
+                                        closestTarget = closestVehicle;
+                                        for (APart part : closestTarget.parts) {
                                             if (part instanceof PartEngine) {
                                                 engineTarget = (PartEngine) part;
                                                 break;
@@ -703,18 +706,21 @@ public class PartGun extends APart {
                             case GROUND: {
                                 Point3D gunLookVec = new Point3D(0,0,1).rotate(orientation);
                                 EntityVehicleF_Physics closestVehicle;
-                                IWrapperEntity closestMob;
+                                EntityVehicleF_Physics closestTarget;
                                 double minDist = definition.gun.lockRange;
                                 for (EntityVehicleF_Physics ivEntity : world.getEntitiesOfType(EntityVehicleF_Physics.class)) {
                                     Point3D vecToTarget = ivEntity.position.copy().subtract(position).normalize();
                                     double targetAngle = Math.abs(Math.toDegrees(Math.acos(vecToTarget.dotProduct(gunLookVec, false))));
                                     double dist = ivEntity.position.distanceTo(position);
-                                    if (!ivEntity.isValid || ivEntity.outOfHealth || targetAngle > definition.gun.lockMaxAngle || dist > minDist || ivEntity == this.entityOn || ivEntity.definition.motorized.isAircraft) {
+                                    if (!ivEntity.isValid || targetAngle > definition.gun.lockMaxAngle || dist > minDist || ivEntity == this.entityOn || ivEntity.definition.motorized.isAircraft) {
                                         engineTarget = null;
                                     } else {
                                         closestVehicle = ivEntity;
+                                    }
+                                    if (closestVehicle != null && !closestVehicle.outOfHealth) {
                                         minDist = dist;
-                                        for (APart part : closestVehicle.parts) {
+                                        closestTarget = closestVehicle;
+                                        for (APart part : closestTarget.parts) {
                                             if (part instanceof PartEngine) {
                                                 engineTarget = (PartEngine) part;
                                                 break;
@@ -727,18 +733,21 @@ public class PartGun extends APart {
                             case HARD: {
                                 Point3D gunLookVec = new Point3D(0,0,1).rotate(orientation);
                                 EntityVehicleF_Physics closestVehicle;
-                                IWrapperEntity closestMob;
+                                EntityVehicleF_Physics closestTarget;
                                 double minDist = definition.gun.lockRange;
                                 for (EntityVehicleF_Physics ivEntity : world.getEntitiesOfType(EntityVehicleF_Physics.class)) {
                                     Point3D vecToTarget = ivEntity.position.copy().subtract(position).normalize();
                                     double targetAngle = Math.abs(Math.toDegrees(Math.acos(vecToTarget.dotProduct(gunLookVec, false))));
                                     double dist = ivEntity.position.distanceTo(position);
-                                    if (!ivEntity.isValid || ivEntity.outOfHealth || targetAngle > definition.gun.lockMaxAngle || dist > minDist || ivEntity == this.entityOn) {
+                                    if (!ivEntity.isValid || targetAngle > definition.gun.lockMaxAngle || dist > minDist || ivEntity == this.entityOn) {
                                         engineTarget = null;
                                     } else {
                                         closestVehicle = ivEntity;
+                                    }
+                                    if (closestVehicle != null && !closestVehicle.outOfHealth) {
                                         minDist = dist;
-                                        for (APart part : closestVehicle.parts) {
+                                        closestTarget = closestVehicle;
+                                        for (APart part : closestTarget.parts) {
                                             if (part instanceof PartEngine) {
                                                 engineTarget = (PartEngine) part;
                                                 break;

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
@@ -612,7 +612,7 @@ public class PartGun extends APart {
                         if (entityTarget == null) {
                             engineTarget = null;
                             EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
-                            if (vehicleTargeted != null && !vehicleTargeted.outOfHealth) {
+                            if (vehicleTargeted != null) {
                                 for (APart part : vehicleTargeted.parts) {
                                     if (part instanceof PartEngine) {
                                         engineTarget = (PartEngine) part;

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
@@ -601,18 +601,18 @@ public class PartGun extends APart {
             //Player-controlled gun.
             //Check for a target for this gun if we have a lock-on missile.
             //Only do this once every 1/2 second.
-            //First, check if this bullet is guided
+            //First, check if the loaded bullet is guided
             if (loadedBullet != null && loadedBullet.definition.bullet.turnRate > 0) {
                 //New lock on logic. Determines if it can lock a target
-                //Default old method of lokking at it to lock. Still has its uses for realistic instances.
+                //Default old method of looking at it to lock. Still has its uses for realistic instances.
                 if ((definition.gun.lockOnType == null || definition.gun.lockOnType == LockOnType.DEFAULT) ) {
-                    //check for valid target type. By default it lock any entity.
-                    if (definition.gun.targetTypes == null || definition.gun.targetTypes.contains(TargetTypes.ALL)) {
+                    //check for valid target type. By default it locks any entity.
+                    if (definition.gun.targetType == TargetType.ALL) {
                         entityTarget = world.getEntityLookingAt(controller, RAYTRACE_DISTANCE, true);
                         if (entityTarget == null) {
                             engineTarget = null;
                             EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
-                            if (vehicleTargeted != null) {
+                            if (vehicleTargeted != null && !vehicleTargeted.outOfHealth) {
                                 for (APart part : vehicleTargeted.parts) {
                                     if (part instanceof PartEngine) {
                                         engineTarget = (PartEngine) part;
@@ -622,43 +622,52 @@ public class PartGun extends APart {
                             }
                         }
                         //Locks only onto aircraft
-                    } else if (!definition.gun.targetTypes.contains(TargetTypes.ALL) && definition.gun.targetTypes.contains(TargetTypes.AIRCRAFT)) {
+                    } else if (definition.gun.targetType == TargetType.AIRCRAFT) {
                         if (entityTarget == null) {
                             engineTarget = null;
                             EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
-                            if (vehicleTargeted != null) {
-                                if (vehicleTargeted.definition.motorized.isAircraft) {
-                                    for (APart part : vehicleTargeted.parts) {
-                                        if (part instanceof PartEngine) {
-                                            engineTarget = (PartEngine) part;
-                                            break;
-                                        }
+                            if (vehicleTargeted != null && !vehicleTargeted.outOfHealth && vehicleTargeted.definition.motorized.isAircraft) {
+                                for (APart part : vehicleTargeted.parts) {
+                                    if (part instanceof PartEngine) {
+                                        engineTarget = (PartEngine) part;
+                                        break;
                                     }
                                 }
                             }
                         }
                         //Locks only onto ground vehicles
-                    } else if (!definition.gun.targetTypes.contains(TargetTypes.ALL) && definition.gun.targetTypes.contains(TargetTypes.GROUND)) {
+                    } else if (definition.gun.targetType == TargetType.GROUND) {
                         if (entityTarget == null) {
                             engineTarget = null;
                             EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
-                            if (vehicleTargeted != null) {
-                                if (!vehicleTargeted.definition.motorized.isAircraft) {
-                                    for (APart part : vehicleTargeted.parts) {
-                                        if (part instanceof PartEngine) {
-                                            engineTarget = (PartEngine) part;
-                                            break;
-                                        }
+                            if (vehicleTargeted != null && !vehicleTargeted.outOfHealth && !vehicleTargeted.definition.motorized.isAircraft) {
+                                for (APart part : vehicleTargeted.parts) {
+                                    if (part instanceof PartEngine) {
+                                        engineTarget = (PartEngine) part;
+                                        break;
                                     }
                                 }
                             }
                         }
                         //Locks only onto players or mobs. "soft targets"
-                    } else if (!definition.gun.targetTypes.contains(TargetTypes.ALL) && definition.gun.targetTypes.contains(TargetTypes.SOFT)) {
+                    } else if (definition.gun.targetType == TargetType.HARD) {
+                        if (entityTarget == null) {
+                            engineTarget = null;
+                            EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
+                            if (vehicleTargeted != null && !vehicleTargeted.outOfHealth) {
+                                for (APart part : vehicleTargeted.parts) {
+                                    if (part instanceof PartEngine) {
+                                        engineTarget = (PartEngine) part;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        //Locks onto either ground or air vehicles.
+                    } else if (definition.gun.targetType == TargetType.SOFT) {
                         entityTarget = world.getEntityLookingAt(controller, RAYTRACE_DISTANCE, true);
                     }
                 }
-
             }
 
             //If we are holding the trigger, request to fire.

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
@@ -610,8 +610,8 @@ public class PartGun extends APart {
                 //We are the type of bullet to get a target, figure out if we need one, or we don't do auto-targeting.
                 //If we do auto-target, we need to create a vector to look though.
                 Point3D startPoint = null;
-                Point3D searchVector;
-                double coneAngle;
+                Point3D searchVector = null;
+                double coneAngle = 0;
                 switch (definition.gun.lockOnType) {
                     case DEFAULT: {
                         //Default gets target based on controller eyes and where they are looking.
@@ -681,7 +681,6 @@ public class PartGun extends APart {
                     //If we didn't find a hard vehicle target, try and get a soft one.
                     if (engineTarget == null && definition.gun.targetType == TargetType.ALL || definition.gun.targetType == TargetType.SOFT) {
                         normalizedConeVector.set(searchVector).normalize();
-                        IWrapperEntity foundEntity = null;
                         double smallestDistance = searchVector.length();
                         BoundingBox searchBox = new BoundingBox(position, smallestDistance, smallestDistance, smallestDistance);
                         for (IWrapperEntity entity : world.getEntitiesWithin(searchBox)) {

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
@@ -670,18 +670,102 @@ public class PartGun extends APart {
                         //rather than what the player looks at.
                         switch (definition.gun.targetType) {
                             case ALL: {
+                                //Impractical to use this
                                 break;
                             }
                             case AIRCRAFT: {
+                                Point3D gunLookVec = new Point3D(0,0,1).rotate(orientation);
+                                EntityVehicleF_Physics closestVehicle;
+                                IWrapperEntity closestMob;
+                                double minDist = definition.gun.lockRange;
+                                for (EntityVehicleF_Physics ivEntity : world.getEntitiesOfType(EntityVehicleF_Physics.class)) {
+                                    Point3D vecToTarget = ivEntity.position.copy().subtract(position).normalize();
+                                    double targetAngle = Math.abs(Math.toDegrees(Math.acos(vecToTarget.dotProduct(gunLookVec, false))));
+                                    double dist = ivEntity.position.distanceTo(position);
+                                    if (!ivEntity.isValid || ivEntity.outOfHealth || targetAngle > definition.gun.lockMaxAngle || dist > minDist || ivEntity == this.entityOn || !ivEntity.definition.motorized.isAircraft) {
+                                        engineTarget = null;
+                                    } else {
+                                        closestVehicle = ivEntity;
+                                        minDist = dist;
+                                        for (APart part : closestVehicle.parts) {
+                                            if (part instanceof PartEngine) {
+                                                engineTarget = (PartEngine) part;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
                                 break;
                             }
                             case GROUND: {
+                                Point3D gunLookVec = new Point3D(0,0,1).rotate(orientation);
+                                EntityVehicleF_Physics closestVehicle;
+                                IWrapperEntity closestMob;
+                                double minDist = definition.gun.lockRange;
+                                for (EntityVehicleF_Physics ivEntity : world.getEntitiesOfType(EntityVehicleF_Physics.class)) {
+                                    Point3D vecToTarget = ivEntity.position.copy().subtract(position).normalize();
+                                    double targetAngle = Math.abs(Math.toDegrees(Math.acos(vecToTarget.dotProduct(gunLookVec, false))));
+                                    double dist = ivEntity.position.distanceTo(position);
+                                    if (!ivEntity.isValid || ivEntity.outOfHealth || targetAngle > definition.gun.lockMaxAngle || dist > minDist || ivEntity == this.entityOn || ivEntity.definition.motorized.isAircraft) {
+                                        engineTarget = null;
+                                    } else {
+                                        closestVehicle = ivEntity;
+                                        minDist = dist;
+                                        for (APart part : closestVehicle.parts) {
+                                            if (part instanceof PartEngine) {
+                                                engineTarget = (PartEngine) part;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
                                 break;
                             }
                             case HARD: {
+                                Point3D gunLookVec = new Point3D(0,0,1).rotate(orientation);
+                                EntityVehicleF_Physics closestVehicle;
+                                IWrapperEntity closestMob;
+                                double minDist = definition.gun.lockRange;
+                                for (EntityVehicleF_Physics ivEntity : world.getEntitiesOfType(EntityVehicleF_Physics.class)) {
+                                    Point3D vecToTarget = ivEntity.position.copy().subtract(position).normalize();
+                                    double targetAngle = Math.abs(Math.toDegrees(Math.acos(vecToTarget.dotProduct(gunLookVec, false))));
+                                    double dist = ivEntity.position.distanceTo(position);
+                                    if (!ivEntity.isValid || ivEntity.outOfHealth || targetAngle > definition.gun.lockMaxAngle || dist > minDist || ivEntity == this.entityOn) {
+                                        engineTarget = null;
+                                    } else {
+                                        closestVehicle = ivEntity;
+                                        minDist = dist;
+                                        for (APart part : closestVehicle.parts) {
+                                            if (part instanceof PartEngine) {
+                                                engineTarget = (PartEngine) part;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
                                 break;
                             }
                             case SOFT: {
+                                Point3D gunLookVec = new Point3D(0,0,1).rotate(orientation);
+                                IWrapperEntity closestEnt;
+                                double minDist = definition.gun.lockRange;
+                                for (IWrapperEntity entity : world.getEntitiesWithin(new BoundingBox(position, minDist,minDist,minDist))) {
+                                    Point3D vecToTarget = entity.getPosition().copy().subtract(position).normalize();
+                                    double targetAngle = Math.abs(Math.toDegrees(Math.acos(vecToTarget.dotProduct(gunLookVec, false))));
+                                    double dist = entity.getPosition().distanceTo(position);
+                                    if (targetAngle > definition.gun.lockMaxAngle || dist > minDist) {
+                                        entityTarget = null;
+                                    } else {
+                                        closestEnt = entity;
+                                        //Don't target ourself
+                                        if (closestEnt == controller) {
+                                            entityTarget = null;
+                                        } else {
+                                            entityTarget = closestEnt;
+                                            break;
+                                        }
+                                    }
+                                }
                                 break;
                             }
                         }

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
@@ -653,7 +653,7 @@ public class PartGun extends APart {
                         double smallestDistance = searchVector.length();
                         for (EntityVehicleF_Physics vehicle : world.getEntitiesOfType(EntityVehicleF_Physics.class)) {
                             //Make sure we don't lock-on to our own vehicle.  Also, ensure if we want aircraft, or ground, we only get those.
-                            if (vehicle != vehicleOn && !vehicle.outOfHealth && (definition.gun.targetType != TargetType.AIRCRAFT || vehicle.definition.motorized.isAircraft) && (definition.gun.targetType != TargetType.GROUND || !vehicle.definition.motorized.isAircraft)) {
+                            if (vehicle != vehicleOn && (definition.gun.targetType != TargetType.AIRCRAFT || vehicle.definition.motorized.isAircraft) && (definition.gun.targetType != TargetType.GROUND || !vehicle.definition.motorized.isAircraft)) {
                                 double entityDistance = vehicle.position.distanceTo(startPoint);
                                 if (entityDistance < smallestDistance) {
                                     //Potential match by distance, check if the entity is inside the cone.
@@ -668,7 +668,7 @@ public class PartGun extends APart {
                         }
 
                         //If we found a vehicle, get the engine to target.
-                        if (vehicleTarget != null) {
+                        if (vehicleTarget != null && !vehicleTarget.outOfHealth) {
                             for (APart part : vehicleTarget.parts) {
                                 if (part instanceof PartEngine) {
                                     engineTarget = (PartEngine) part;

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
@@ -685,7 +685,7 @@ public class PartGun extends APart {
                         double smallestDistance = searchVector.length();
                         BoundingBox searchBox = new BoundingBox(position, smallestDistance, smallestDistance, smallestDistance);
                         for (IWrapperEntity entity : world.getEntitiesWithin(searchBox)) {
-                            if (entity.isValid() && entity != lastController) {
+                            if (entity.isValid() && entity != controller) {
                                 double entityDistance = entity.getPosition().distanceTo(startPoint);
                                 if (entityDistance < smallestDistance) {
                                     //Potential match by distance, check if the entity is inside the cone.

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONBullet.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONBullet.java
@@ -16,6 +16,9 @@ public class JSONBullet extends AJSONMultiModelProvider {
         @JSONRequired
         @JSONDescription("A list of types describing the bullet.  This defines how it inflicts damage on whatever it hits.")
         public List<BulletType> types;
+        
+        @JSONDescription("Different ways for a bullet to be guided to its target once fired.")
+        public GuidanceType guidanceType;
 
         @JSONDescription("If true, then this bullet will be considered a HEAT bullet and will use the HEAT armor value on any collision boxes it finds.  If that value isn't defined, it will just use the normal armor value.")
         public boolean isHeat;
@@ -87,5 +90,16 @@ public class JSONBullet extends AJSONMultiModelProvider {
         WATER,
         @JSONDescription("A bullet that pierces player armor.  Useful for pesky super-suits.")
         ARMOR_PIERCING
+    }
+    
+    public enum GuidanceType {
+        @JSONDescription("Default fire and forget. Projectile Actively searches for its target.")
+        DEFAULT,
+        @JSONDescription("Must maintain lock until impact")
+        SEMI_ACTIVE,
+        @JSONDescription("Goes where the player is looking")
+        LASER,
+        @JSONDescription("Locks on to hot things like engines. Can be fooled with flares.")
+        INFRARED
     }
 }

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONBullet.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONBullet.java
@@ -16,9 +16,6 @@ public class JSONBullet extends AJSONMultiModelProvider {
         @JSONRequired
         @JSONDescription("A list of types describing the bullet.  This defines how it inflicts damage on whatever it hits.")
         public List<BulletType> types;
-        
-        @JSONDescription("Different ways for a bullet to be guided to its target once fired.")
-        public GuidanceType guidanceType;
 
         @JSONDescription("If true, then this bullet will be considered a HEAT bullet and will use the HEAT armor value on any collision boxes it finds.  If that value isn't defined, it will just use the normal armor value.")
         public boolean isHeat;
@@ -92,14 +89,4 @@ public class JSONBullet extends AJSONMultiModelProvider {
         ARMOR_PIERCING
     }
     
-    public enum GuidanceType {
-        @JSONDescription("Default fire and forget. Projectile Actively searches for its target.")
-        DEFAULT,
-        @JSONDescription("Must maintain lock until impact")
-        SEMI_ACTIVE,
-        @JSONDescription("Goes where the player is looking")
-        LASER,
-        @JSONDescription("Locks on to hot things like engines. Can be fooled with flares.")
-        INFRARED
-    }
 }

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
@@ -433,6 +433,12 @@ public class JSONPart extends AJSONPartProvider {
 
         @JSONDescription("Used when resetPosition is true. Defaults to 0 if not set.")
         public float defaultPitch;
+        
+        @JSONDescription("How far away the gun will be able to lock targets.")
+        public int lockRange;
+
+        @JSONDescription("Angle in degrees around gun's orientation that it wil see targets.")
+        public double lockMaxAngle;
 
         @JSONRequired(dependentField = "handHeld", dependentValues = {"true"})
         @JSONDescription("The offset where this gun will be when held normally by the player.  An offset of 0,0,0 will render the gun in the center of the player's right shoulder rotation point.  For reference, this is 0.3125 blocks to the right, and 1.375 blocks from the bottom-center of the player's feet.")

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
@@ -353,6 +353,12 @@ public class JSONPart extends AJSONPartProvider {
     }
 
     public static class JSONPartGun {
+        @JSONDescription("How a gun that has guided bullets determines if it has a lock.")
+        public LockOnType lockOnType;
+
+        @JSONDescription("A list of target types for a guided weapon. Aloows fo locking one type of thing, but not another.")
+        public List<TargetTypes> targetTypes;
+        
         @JSONDescription("If set, this causes the gun to automatically reload from the vehicle's inventory when its ammo count hits 0.  Guns will prefer to reload the same ammo that was previously in the gun, and will only reload different (yet compatible) ammo if the old ammo is not found.")
         public boolean autoReload;
 
@@ -442,6 +448,28 @@ public class JSONPart extends AJSONPartProvider {
 
         @Deprecated
         public float length;
+    }
+    
+    public enum LockOnType {
+        @JSONDescription("Look at stuff to get a lock")
+        DEFAULT,
+        @JSONDescription("The gun itself must see the target.")
+        BORESIGHT,
+        @JSONDescription("Goes where the player is pointed")
+        MANUAL,
+        @JSONDescription("Goes where the radar tells it to.")
+        RADAR
+    }
+
+    public enum TargetTypes {
+        @JSONDescription("Will lock on to anything. Default")
+        ALL,
+        @JSONDescription("Only Locks onto ground vehicles.")
+        GROUND,
+        @JSONDescription("Only locks on to aircraft.")
+        AIRCRAFT,
+        @JSONDescription("Only locks on to players or mobs.")
+        SOFT
     }
 
     public static class JSONPartInteractable {

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
@@ -356,8 +356,8 @@ public class JSONPart extends AJSONPartProvider {
         @JSONDescription("How a gun that has guided bullets determines if it has a lock.")
         public LockOnType lockOnType;
 
-        @JSONDescription("A list of target types for a guided weapon. Aloows fo locking one type of thing, but not another.")
-        public List<TargetTypes> targetTypes;
+        @JSONDescription("Type of target this gun can lock on to.")
+        public TargetType targetType;
         
         @JSONDescription("If set, this causes the gun to automatically reload from the vehicle's inventory when its ammo count hits 0.  Guns will prefer to reload the same ammo that was previously in the gun, and will only reload different (yet compatible) ammo if the old ammo is not found.")
         public boolean autoReload;
@@ -461,13 +461,15 @@ public class JSONPart extends AJSONPartProvider {
         RADAR
     }
 
-    public enum TargetTypes {
+    public enum TargetType {
         @JSONDescription("Will lock on to anything. Default")
         ALL,
         @JSONDescription("Only Locks onto ground vehicles.")
         GROUND,
         @JSONDescription("Only locks on to aircraft.")
         AIRCRAFT,
+        @JSONDescription("Will lock either aircraft or ground vehicles. Hard targets.")
+        HARD,
         @JSONDescription("Only locks on to players or mobs.")
         SOFT
     }

--- a/mccore/src/main/java/minecrafttransportsimulator/mcinterface/AWrapperWorld.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/mcinterface/AWrapperWorld.java
@@ -117,13 +117,6 @@ public abstract class AWrapperWorld extends EntityManager {
     public abstract List<IWrapperEntity> getEntitiesHostile(IWrapperEntity lookingEntity, double radius);
 
     /**
-     * Returns the closest entity whose collision boxes are intercepted by the
-     * passed-in entity's line of sight.  This up-scales the entity Bounding Boxes to
-     * allow for a somewhat easier targeting scheme if generalArea is true.
-     */
-    public abstract IWrapperEntity getEntityLookingAt(IWrapperEntity entityLooking, float searchDistance, boolean generalArea);
-
-    /**
      * Spawns the brand-new entity into the world.
      */
     public abstract void spawnEntity(AEntityB_Existing entity);

--- a/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
@@ -24,7 +24,6 @@ import minecrafttransportsimulator.jsondefs.JSONAnimatedObject;
 import minecrafttransportsimulator.jsondefs.JSONAnimationDefinition;
 import minecrafttransportsimulator.jsondefs.JSONAnimationDefinition.AnimationComponentType;
 import minecrafttransportsimulator.jsondefs.JSONBullet;
-import minecrafttransportsimulator.jsondefs.JSONBullet.GuidanceType;
 import minecrafttransportsimulator.jsondefs.JSONCollisionBox;
 import minecrafttransportsimulator.jsondefs.JSONCollisionGroup;
 import minecrafttransportsimulator.jsondefs.JSONConnection;

--- a/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
@@ -768,8 +768,8 @@ public final class LegacyCompatSystem {
             if (definition.gun.lockOnType == null) {
                 definition.gun.lockOnType = JSONPart.LockOnType.DEFAULT;
             }
-            if (definition.gun.targetTypes == null) {
-                definition.gun.targetTypes = Collections.singletonList(JSONPart.TargetTypes.ALL);
+            if (definition.gun.targetType == null) {
+                definition.gun.targetType = JSONPart.TargetType.ALL;
             }
             definition.gun.length = 0;
         }

--- a/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
@@ -1673,7 +1673,7 @@ public final class LegacyCompatSystem {
         }
          //Default duidance if not specified
         if(definition.bullet.turnRate > 0 && definition.bullet.guidanceTypes == null) {
-           definition.bullet.guidanceTypes = Collections.singletonList(GuidanceType.VISUAL);
+           definition.bullet.guidanceTypes = Collections.singletonList(GuidanceType.DEFAULT);
         }
 
         //Add damage value.

--- a/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
@@ -1677,10 +1677,6 @@ public final class LegacyCompatSystem {
             subDefinition.subName = "";
             definition.definitions.add(subDefinition);
         }
-         //Default duidance if not specified
-        if(definition.bullet.turnRate > 0 && definition.bullet.guidanceType == null) {
-           definition.bullet.guidanceType = JSONBullet.GuidanceType.DEFAULT;
-        }
 
         //Add damage value.
         if (definition.bullet.damage == 0) {

--- a/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
@@ -765,6 +765,12 @@ public final class LegacyCompatSystem {
                 muzzleGroup.muzzles.add(muzzle);
                 definition.gun.muzzleGroups.add(muzzleGroup);
             }
+            if (definition.gun.lockOnType == null) {
+                definition.gun.lockOnType = JSONPart.LockOnType.DEFAULT;
+            }
+            if (definition.gun.targetTypes == null) {
+                definition.gun.targetTypes = Collections.singletonList(JSONPart.TargetTypes.ALL);
+            }
             definition.gun.length = 0;
         }
 
@@ -1672,8 +1678,8 @@ public final class LegacyCompatSystem {
             definition.definitions.add(subDefinition);
         }
          //Default duidance if not specified
-        if(definition.bullet.turnRate > 0 && definition.bullet.guidanceTypes == null) {
-           definition.bullet.guidanceTypes = Collections.singletonList(GuidanceType.DEFAULT);
+        if(definition.bullet.turnRate > 0 && definition.bullet.guidanceType == null) {
+           definition.bullet.guidanceType = JSONBullet.GuidanceType.DEFAULT;
         }
 
         //Add damage value.

--- a/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
@@ -24,6 +24,7 @@ import minecrafttransportsimulator.jsondefs.JSONAnimatedObject;
 import minecrafttransportsimulator.jsondefs.JSONAnimationDefinition;
 import minecrafttransportsimulator.jsondefs.JSONAnimationDefinition.AnimationComponentType;
 import minecrafttransportsimulator.jsondefs.JSONBullet;
+import minecrafttransportsimulator.jsondefs.JSONBullet.GuidanceType;
 import minecrafttransportsimulator.jsondefs.JSONCollisionBox;
 import minecrafttransportsimulator.jsondefs.JSONCollisionGroup;
 import minecrafttransportsimulator.jsondefs.JSONConnection;
@@ -1669,6 +1670,10 @@ public final class LegacyCompatSystem {
             subDefinition.name = definition.general.name;
             subDefinition.subName = "";
             definition.definitions.add(subDefinition);
+        }
+         //Default duidance if not specified
+        if(definition.bullet.turnRate > 0 && definition.bullet.guidanceTypes == null) {
+           definition.bullet.guidanceTypes = Collections.singletonList(GuidanceType.VISUAL);
         }
 
         //Add damage value.

--- a/mcinterfaceforge1122/src/main/java/mcinterface1122/WrapperWorld.java
+++ b/mcinterfaceforge1122/src/main/java/mcinterface1122/WrapperWorld.java
@@ -215,7 +215,7 @@ public class WrapperWorld extends AWrapperWorld {
     public List<IWrapperEntity> getEntitiesWithin(BoundingBox box) {
         List<IWrapperEntity> entities = new ArrayList<>();
         for (Entity entity : world.getEntitiesWithinAABB(Entity.class, WrapperWorld.convert(box))) {
-            if (!(entity instanceof ABuilderEntityBase)) {
+            if (entity instanceof EntityLivingBase) {
                 entities.add(WrapperEntity.getWrapperFor(entity));
             }
         }
@@ -232,30 +232,6 @@ public class WrapperWorld extends AWrapperWorld {
             }
         }
         return entities;
-    }
-
-    @Override
-    public IWrapperEntity getEntityLookingAt(IWrapperEntity entityLooking, float searchDistance, boolean generalArea) {
-        double smallestDistance = searchDistance * 2;
-        Entity foundEntity = null;
-        Entity mcLooker = ((WrapperEntity) entityLooking).entity;
-        Vec3d raytraceStart = mcLooker.getPositionVector().add(0, (entityLooking.getEyeHeight() + entityLooking.getSeatOffset()), 0);
-        Point3D lookerLos = entityLooking.getLineOfSight(searchDistance);
-        Vec3d raytraceEnd = new Vec3d(lookerLos.x, lookerLos.y, lookerLos.z).add(raytraceStart);
-        for (Entity entity : world.getEntitiesWithinAABBExcludingEntity(mcLooker, mcLooker.getEntityBoundingBox().grow(searchDistance))) {
-            if (!(entity instanceof ABuilderEntityBase) && entity.canBeCollidedWith() && !entity.equals(mcLooker.getRidingEntity())) {
-                float distance = mcLooker.getDistance(entity);
-                if (distance < smallestDistance) {
-                    AxisAlignedBB testBox = generalArea ? entity.getEntityBoundingBox().grow(2F * distance / searchDistance) : entity.getEntityBoundingBox();
-                    RayTraceResult rayTrace = testBox.calculateIntercept(raytraceStart, raytraceEnd);
-                    if (rayTrace != null) {
-                        smallestDistance = distance;
-                        foundEntity = entity;
-                    }
-                }
-            }
-        }
-        return WrapperEntity.getWrapperFor(foundEntity);
     }
 
     @Override


### PR DESCRIPTION
Allows for guns to distinguish between different types of targets to lock on to. the default is it will lock how it normally does. However they can be configured to only lock planes, only lock ground vehicles, lock soft targets i.e. mobs/players.
This allows true air-to-air, or air-to-ground, etc. specific weapons.

Note: LockOnType is WIP and non functional at the moment with the exception of the default method.