### PR TITLE
Added Screwdriver Item

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
@@ -262,16 +262,27 @@ public abstract class APart extends AEntityF_Multipart<JSONPart> {
             return;
         }
 
-        //If we are holding a wrench, and the part has children, don't add the interaction boxes.  We can't wrench those parts.
-        //The only exceptions are parts that have permanent-default parts on them. or if they specifically don't block subpart removal.  These can be wrenched.
-        //Again, this only applies on clients for that client player.
-        if (world.isClient() && InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.WRENCH)) {
-            for (APart childPart : parts) {
-                if (!childPart.isPermanent && !childPart.placementDefinition.allowParentRemoval) {
-                    allInteractionBoxes.removeAll(interactionBoxes);
-                    return;
-                }
-            }
+        //If we are holding a screwdriver or wrench, run these checks to remove hitboxes if needed. This can only be done on the client.
+        if (world.isClient()) {
+	    	boolean isHoldingWrench = InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.WRENCH);
+	    	boolean isHoldingScrewdriver = InterfaceManager.clientInterface.getClientPlayer().isHoldingItemType(ItemComponentType.SCREWDRIVER);
+	
+	        if (isHoldingWrench || isHoldingScrewdriver) {
+	            //If we are holding a wrench and the part requires a screwdriver, remove interaction boxes so they don't get in the way and vice versa.
+	            if ((isHoldingWrench && definition.generic.mustBeRemovedByScrewdriver) || (isHoldingScrewdriver && !definition.generic.mustBeRemovedByScrewdriver)) {
+	                allInteractionBoxes.removeAll(interactionBoxes);
+	                return;
+	            }
+	            //If we are holding a wrench or screwdriver, and the part has children, don't add the interaction boxes.  We can't wrench those parts.
+	            //The only exceptions are parts that have permanent-default parts on them. or if they specifically don't block subpart removal.  These can be removed.
+	            //Again, this only applies on clients for that client player.
+	        	for (APart childPart : parts) {
+	                if (!childPart.isPermanent && !childPart.placementDefinition.allowParentRemoval) {
+	                    allInteractionBoxes.removeAll(interactionBoxes);
+	                    return;
+	                }
+	            }
+	        }
         }
     }
 

--- a/mccore/src/main/java/minecrafttransportsimulator/items/instances/ItemItem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/items/instances/ItemItem.java
@@ -54,13 +54,14 @@ public class ItemItem extends AItemPack<JSONItem> implements IItemEntityInteract
 
     @Override
     public boolean canBreakBlocks() {
-        return !definition.item.type.equals(ItemComponentType.WRENCH);
+        return !(definition.item.type.equals(ItemComponentType.WRENCH) || definition.item.type.equals(ItemComponentType.SCREWDRIVER));
     }
 
     @Override
     public CallbackType doEntityInteraction(AEntityE_Interactable<?> entity, BoundingBox hitBox, IWrapperPlayer player, PlayerOwnerState ownerState, boolean rightClick) {
         switch (definition.item.type) {
-            case WRENCH: {
+	    	case WRENCH: 
+	    	case SCREWDRIVER: {
                 if (!entity.world.isClient()) {
                     //If the player isn't the owner of the entity, they can't interact with it.
                     if (!ownerState.equals(PlayerOwnerState.USER)) {

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONItem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONItem.java
@@ -97,6 +97,8 @@ public class JSONItem extends AJSONItem {
         SCANNER,
         @JSONDescription("Creates an item that works as a wrench.")
         WRENCH,
+        @JSONDescription("Creates an item that works as a screwdriver.")
+        SCREWDRIVER,
         @JSONDescription("Creates an item that works as a paint gun.")
         PAINT_GUN,
         @JSONDescription("Creates an item that works as a key.")

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
@@ -93,6 +93,9 @@ public class JSONPart extends AJSONPartProvider {
         @JSONDescription("If true, this part will be able to be removed by hand and without a wrench.  This also bypasses owner requirements (but not vehicle locking).  Useful for small parts like luggage that anyone should be able to remove at any time.")
         public boolean canBeRemovedByHand;
 
+        @JSONDescription("If true, this part will be able to be removed by hand and without a wrench.  This also bypasses owner requirements (but not vehicle locking).  Useful for small parts like luggage that anyone should be able to remove at any time.")
+        public boolean mustBeRemovedByScrewdriver;
+
         @JSONDescription("If true, this part will forward damage onto the vehicle it is on when hit by a bullet.  This will also cause the bullet to stop when it hits this part.  Engines ignore this behavior and always forward damage.")
         public boolean forwardsDamage;
 


### PR DESCRIPTION
Adds a screwdriver item that acts like a mutually exclusive wrench. 

Normally a screw driver won't do anything. However, if a part has `"mustBeRemovedByScrewdriver": true` in its generic section then it can only be removed with a screwdriver item, and a wrench will do nothing.