### PR TITLE
Modified canBeClicked()

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
@@ -339,7 +339,7 @@ public abstract class APart extends AEntityF_Multipart<JSONPart> {
 
     @Override
     public boolean canBeClicked() {
-        return entityOn.isVariableListTrue(placementDefinition.interactableVariables);
+        return entityOn.isVariableListTrue(placementDefinition.interactableVariables) ? entityOn.canBeClicked() : false;
     }
 
     /**

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
@@ -339,7 +339,7 @@ public abstract class APart extends AEntityF_Multipart<JSONPart> {
 
     @Override
     public boolean canBeClicked() {
-        return entityOn.isVariableListTrue(placementDefinition.interactableVariables) ? entityOn.canBeClicked() : false;
+        return entityOn.isVariableListTrue(placementDefinition.interactableVariables) && entityOn.canBeClicked();
     }
 
     /**


### PR DESCRIPTION
Currently interactable variables do not block child parts. This fixes that. Now if a part is not interactable, then all the child parts will also not be interactable.