### PR TITLE
Add ProNav for bullets

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityBullet.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityBullet.java
@@ -166,6 +166,10 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
                     targetPosition = null;
                 }
             } else if (engineTargeted != null) {
+                Point3D predictedCollisionPoint = new Point3D();
+                double ticksToTarget = targetPosition.distanceTo(position) / (velocity / 20D / 10D);
+                predictedCollisionPoint.set(engineTargeted.vehicleOn.position).add(((((engineTargeted.vehicleOn.motion.x * engineTargeted.vehicleOn.speedFactor) / 20D) / 10D) * ticksToTarget) , ((((engineTargeted.vehicleOn.motion.y * engineTargeted.vehicleOn.speedFactor) / 20D) / 10D) * ticksToTarget), ((((engineTargeted.vehicleOn.motion.z * engineTargeted.vehicleOn.speedFactor) / 20D) / 10D) * ticksToTarget));
+                targetPosition.set(predictedCollisionPoint);
                 //Don't need to update the position variable for engines, as it auto-syncs.
                 //Do need to check if the engine is still warm and valid, however.
                 if (!engineTargeted.isValid) {// || engineTargeted.temp <= PartEngine.COLD_TEMP){

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityBullet.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityBullet.java
@@ -168,7 +168,7 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
             } else if (engineTargeted != null) {
                 Point3D predictedCollisionPoint = new Point3D();
                 double ticksToTarget = targetPosition.distanceTo(position) / (velocity / 20D / 10D);
-                predictedCollisionPoint.set(engineTargeted.vehicleOn.position).add(((((engineTargeted.vehicleOn.motion.x * engineTargeted.vehicleOn.speedFactor) / 20D) / 10D) * ticksToTarget) , ((((engineTargeted.vehicleOn.motion.y * engineTargeted.vehicleOn.speedFactor) / 20D) / 10D) * ticksToTarget), ((((engineTargeted.vehicleOn.motion.z * engineTargeted.vehicleOn.speedFactor) / 20D) / 10D) * ticksToTarget));
+                predictedCollisionPoint.set(engineTargeted.vehicleOn.position).addScaled(engineTargeted.vehicleOn.motion, (engineTargeted.vehicleOn.speedFactor/ 20D/10D) * ticksToTarget);
                 targetPosition.set(predictedCollisionPoint);
                 //Don't need to update the position variable for engines, as it auto-syncs.
                 //Do need to check if the engine is still warm and valid, however.


### PR DESCRIPTION
Add proportional navigation to guided bullets tracking vehicles. This stops bullets from "chasing" a target which has a high likelihood of missing it's target at high-aspect angles. This causes the bullet to aim where the moving target will be when the missile arrives. Forcing it to lead the target. This makes guided weapons much more effective and efficient. However it makes them much harder to evade.