### PR TITLE
Add some new guidance mechanics

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
@@ -18,9 +18,11 @@ import minecrafttransportsimulator.jsondefs.JSONAnimationDefinition;
 import minecrafttransportsimulator.jsondefs.JSONMuzzle;
 import minecrafttransportsimulator.jsondefs.JSONPart.InteractableComponentType;
 import minecrafttransportsimulator.jsondefs.JSONPart.TargetType;
+import minecrafttransportsimulator.jsondefs.JSONPart.LockOnType;
 import minecrafttransportsimulator.jsondefs.JSONPartDefinition;
 import minecrafttransportsimulator.jsondefs.JSONText;
 import minecrafttransportsimulator.jsondefs.JSONVariableModifier;
+import minecrafttransportsimulator.mcinterface.AWrapperWorld;
 import minecrafttransportsimulator.mcinterface.IWrapperEntity;
 import minecrafttransportsimulator.mcinterface.IWrapperInventory;
 import minecrafttransportsimulator.mcinterface.IWrapperItemStack;
@@ -88,8 +90,9 @@ public class PartGun extends APart {
     public IWrapperEntity lastController;
     private PartSeat lastControllerSeat;
     private Point3D controllerRelativeLookVector = new Point3D();
-    private IWrapperEntity entityTarget;
-    private PartEngine engineTarget;
+    public IWrapperEntity entityTarget;
+    public PartEngine engineTarget;
+    public Point3D targetPosition;
     public EntityBullet currentBullet;
     private final Point3D bulletPosition = new Point3D();
     private final Point3D bulletVelocity = new Point3D();
@@ -368,6 +371,8 @@ public class PartGun extends APart {
                                             newBullet = new EntityBullet(bulletPosition, bulletVelocity, bulletOrientation, this, entityTarget);
                                         } else if (engineTarget != null) {
                                             newBullet = new EntityBullet(bulletPosition, bulletVelocity, bulletOrientation, this, engineTarget);
+                                        } else if (definition.gun.lockOnType == LockOnType.MANUAL) {
+                                            newBullet = new EntityBullet(bulletPosition, bulletVelocity, bulletOrientation, this, targetPosition);
                                         } else {
                                             //No entity found, just fire missile off in direction facing.
                                             newBullet = new EntityBullet(bulletPosition, bulletVelocity, bulletOrientation, this);
@@ -631,7 +636,7 @@ public class PartGun extends APart {
             //Check for a target for this gun if we have a lock-on missile.
             //Only do this once every 1/2 second.
             //First, check if the loaded bullet is guided
-            if (loadedBullet != null && loadedBullet.definition.bullet.turnRate > 0) {
+            if (definition.gun.canLockTargets || (loadedBullet != null && loadedBullet.definition.bullet.turnRate > 0)) {
                 //We are the type of bullet to get a target, figure out if we need one, or we don't do auto-targeting.
                 //If we do auto-target, we need to create a vector to look though.
                 Point3D startPoint = null;
@@ -642,7 +647,7 @@ public class PartGun extends APart {
                         //Default gets target based on controller eyes and where they are looking.
                         //Need to get their eye position though, not their main position, for accurate targeting.
                         //Also, don't use gun max distance here, since that's only for boresight.
-                        startPoint = controller.getPosition().add(0, (controller.getEyeHeight() + controller.getSeatOffset()), 0);
+                        startPoint = controller.getPosition();
                         searchVector = controller.getLineOfSight(RAYTRACE_DISTANCE);
                         coneAngle = DEFAULT_CONE_ANGLE;
                         break;
@@ -659,7 +664,16 @@ public class PartGun extends APart {
                         break;
                     }
                     case MANUAL: {
-                        //No target to set, and no actions to perform.
+                        if (targetPosition == null) {
+                            targetPosition = new Point3D();
+                        }
+                        Point3D laserStart = new Point3D(controller.getPosition().x, controller.getPosition().y, controller.getPosition().z);
+                        AWrapperWorld.BlockHitResult laserHit = world.getBlockHit(laserStart, controller.getLineOfSight(2048));
+                        if (laserHit != null) {
+                            targetPosition.set(laserHit.position);
+                        } else {
+                            targetPosition.set(laserStart).add(controller.getLineOfSight(1024));
+                        }
                         break;
                     }
                 }
@@ -724,214 +738,6 @@ public class PartGun extends APart {
                         }
                     }
                 }
-
-                /*
-                switch (definition.gun.lockOnType) {
-                    case DEFAULT:{
-                        switch (definition.gun.targetType) {
-                            case ALL:{
-                                entityTarget = world.getEntityLookingAt(controller, RAYTRACE_DISTANCE, true);
-                                if (entityTarget == null) {
-                                    engineTarget = null;
-                                    EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
-                                    if (vehicleTargeted != null && !vehicleTargeted.outOfHealth) {
-                                        for (APart part : vehicleTargeted.parts) {
-                                            if (part instanceof PartEngine) {
-                                                engineTarget = (PartEngine) part;
-                                                break;
-                                            }
-                                        }
-                                    }
-                                }
-                                break;
-                            }
-                            case AIRCRAFT:{
-                                engineTarget = null;
-                                EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
-                                if (vehicleTargeted != null && !vehicleTargeted.outOfHealth && vehicleTargeted.definition.motorized.isAircraft) {
-                                    for (APart part : vehicleTargeted.parts) {
-                                        if (part instanceof PartEngine) {
-                                            engineTarget = (PartEngine) part;
-                                            break;
-                                        }
-                                    }
-                                }
-                                break;
-                            }
-                            case GROUND:{
-                                engineTarget = null;
-                                EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
-                                if (vehicleTargeted != null && !vehicleTargeted.outOfHealth && !vehicleTargeted.definition.motorized.isAircraft) {
-                                    for (APart part : vehicleTargeted.parts) {
-                                        if (part instanceof PartEngine) {
-                                            engineTarget = (PartEngine) part;
-                                            break;
-                                        }
-                                    }
-                                }
-                                break;
-                            }
-                            case HARD:{
-                                engineTarget = null;
-                                EntityVehicleF_Physics vehicleTargeted = world.getRaytraced(EntityVehicleF_Physics.class, controller.getPosition(), controller.getPosition().copy().add(controller.getLineOfSight(RAYTRACE_DISTANCE)), true, vehicleOn);
-                                if (vehicleTargeted != null && !vehicleTargeted.outOfHealth) {
-                                    for (APart part : vehicleTargeted.parts) {
-                                        if (part instanceof PartEngine) {
-                                            engineTarget = (PartEngine) part;
-                                            break;
-                                        }
-                                    }
-                                }
-                                break;
-                            }
-                            case SOFT:{
-                                entityTarget = world.getEntityLookingAt(controller, RAYTRACE_DISTANCE, true);
-                                break;
-                            }
-                        }
-                        break;
-                    }
-                    case BORESIGHT:{
-                        //Sees the closest target within a specified range and angle in front of the gun itself
-                        //rather than what the player looks at.
-                        switch (definition.gun.targetType) {
-                            case ALL: {
-                                //Impractical to use this
-                                break;
-                            }
-                            case AIRCRAFT: {
-                                Point3D gunLookVec = new Point3D(0,0,1).rotate(orientation);
-                                EntityVehicleF_Physics closestVehicle;
-                                EntityVehicleF_Physics closestTarget;
-                                double minDist = definition.gun.lockRange;
-                                for (EntityVehicleF_Physics ivEntity : world.getEntitiesOfType(EntityVehicleF_Physics.class)) {
-                                    Point3D vecToTarget = ivEntity.position.copy().subtract(position).normalize();
-                                    double targetAngle = Math.abs(Math.toDegrees(Math.acos(vecToTarget.dotProduct(gunLookVec, false))));
-                                    double dist = ivEntity.position.distanceTo(position);
-                                    if (!ivEntity.isValid || targetAngle > definition.gun.lockMaxAngle || dist > minDist || ivEntity == this.entityOn || !ivEntity.definition.motorized.isAircraft) {
-                                        engineTarget = null;
-                                    } else {
-                                        closestVehicle = ivEntity;
-                                    }
-                                    if (closestVehicle != null && !closestVehicle.outOfHealth) {
-                                        minDist = dist;
-                                        closestTarget = closestVehicle;
-                                        for (APart part : closestTarget.parts) {
-                                            if (part instanceof PartEngine) {
-                                                engineTarget = (PartEngine) part;
-                                                break;
-                                            }
-                                        }
-                                    }
-                                }
-                                break;
-                            }
-                            case GROUND: {
-                                Point3D gunLookVec = new Point3D(0,0,1).rotate(orientation);
-                                EntityVehicleF_Physics closestVehicle;
-                                EntityVehicleF_Physics closestTarget;
-                                double minDist = definition.gun.lockRange;
-                                for (EntityVehicleF_Physics ivEntity : world.getEntitiesOfType(EntityVehicleF_Physics.class)) {
-                                    Point3D vecToTarget = ivEntity.position.copy().subtract(position).normalize();
-                                    double targetAngle = Math.abs(Math.toDegrees(Math.acos(vecToTarget.dotProduct(gunLookVec, false))));
-                                    double dist = ivEntity.position.distanceTo(position);
-                                    if (!ivEntity.isValid || targetAngle > definition.gun.lockMaxAngle || dist > minDist || ivEntity == this.entityOn || ivEntity.definition.motorized.isAircraft) {
-                                        engineTarget = null;
-                                    } else {
-                                        closestVehicle = ivEntity;
-                                    }
-                                    if (closestVehicle != null && !closestVehicle.outOfHealth) {
-                                        minDist = dist;
-                                        closestTarget = closestVehicle;
-                                        for (APart part : closestTarget.parts) {
-                                            if (part instanceof PartEngine) {
-                                                engineTarget = (PartEngine) part;
-                                                break;
-                                            }
-                                        }
-                                    }
-                                }
-                                break;
-                            }
-                            case HARD: {
-                                Point3D gunLookVec = new Point3D(0,0,1).rotate(orientation);
-                                EntityVehicleF_Physics closestVehicle;
-                                EntityVehicleF_Physics closestTarget;
-                                double minDist = definition.gun.lockRange;
-                                for (EntityVehicleF_Physics ivEntity : world.getEntitiesOfType(EntityVehicleF_Physics.class)) {
-                                    Point3D vecToTarget = ivEntity.position.copy().subtract(position).normalize();
-                                    double targetAngle = Math.abs(Math.toDegrees(Math.acos(vecToTarget.dotProduct(gunLookVec, false))));
-                                    double dist = ivEntity.position.distanceTo(position);
-                                    if (!ivEntity.isValid || targetAngle > definition.gun.lockMaxAngle || dist > minDist || ivEntity == this.entityOn) {
-                                        engineTarget = null;
-                                    } else {
-                                        closestVehicle = ivEntity;
-                                    }
-                                    if (closestVehicle != null && !closestVehicle.outOfHealth) {
-                                        minDist = dist;
-                                        closestTarget = closestVehicle;
-                                        for (APart part : closestTarget.parts) {
-                                            if (part instanceof PartEngine) {
-                                                engineTarget = (PartEngine) part;
-                                                break;
-                                            }
-                                        }
-                                    }
-                                }
-                                break;
-                            }
-                            case SOFT: {
-                                Point3D gunLookVec = new Point3D(0,0,1).rotate(orientation);
-                                IWrapperEntity closestEnt;
-                                double minDist = definition.gun.lockRange;
-                                for (IWrapperEntity entity : world.getEntitiesWithin(new BoundingBox(position, minDist,minDist,minDist))) {
-                                    Point3D vecToTarget = entity.getPosition().copy().subtract(position).normalize();
-                                    double targetAngle = Math.abs(Math.toDegrees(Math.acos(vecToTarget.dotProduct(gunLookVec, false))));
-                                    double dist = entity.getPosition().distanceTo(position);
-                                    if (targetAngle > definition.gun.lockMaxAngle || dist > minDist) {
-                                        entityTarget = null;
-                                    } else {
-                                        closestEnt = entity;
-                                        //Don't target ourself
-                                        if (closestEnt == controller) {
-                                            entityTarget = null;
-                                        } else {
-                                            entityTarget = closestEnt;
-                                            break;
-                                        }
-                                    }
-                                }
-                                break;
-                            }
-                        }
-                        break;
-                    }
-                    case RADAR:{
-                        //select a specific target and lock the vehicle entity itself rather than the engine.
-                        switch (definition.gun.targetType) {
-                            case ALL: {
-                                break;
-                            }
-                            case AIRCRAFT: {
-                                break;
-                            }
-                            case GROUND: {
-                                break;
-                            }
-                            case HARD: {
-                                break;
-                            }
-                            case SOFT: {
-                                break;
-                            }
-                        }
-                        break;
-                    }
-                    case MANUAL:{
-                        //laser guidance. Just goes where the player or camera is pointed.
-                        break;
-                    }
-                }*/
             }
 
             //If we are holding the trigger, request to fire.

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONBullet.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONBullet.java
@@ -17,6 +17,9 @@ public class JSONBullet extends AJSONMultiModelProvider {
         @JSONDescription("A list of types describing the bullet.  This defines how it inflicts damage on whatever it hits.")
         public List<BulletType> types;
 
+        @JSONDescription("Defines the method for how a bullet will guide to it's target.")
+        public GuidanceType guidanceType;
+
         @JSONDescription("If true, then this bullet will be considered a HEAT bullet and will use the HEAT armor value on any collision boxes it finds.  If that value isn't defined, it will just use the normal armor value.")
         public boolean isHeat;
 
@@ -87,6 +90,15 @@ public class JSONBullet extends AJSONMultiModelProvider {
         WATER,
         @JSONDescription("A bullet that pierces player armor.  Useful for pesky super-suits.")
         ARMOR_PIERCING
+    }
+
+    public enum GuidanceType {
+        @JSONDescription("Will track whatever target that was locked prior to firing, However, It will guide to the closest target it can 'see'. Therefore, it is possible to fire without a lock and have it find it's own target with the downside of it being possible to fool.")
+        PASSIVE,
+        @JSONDescription("Tracks the locked target but if the lock is lost, guidance stops.")
+        SEMI_ACTIVE,
+        @JSONDescription("Default method. Tracks whatever target the gun was locked on to prior to firing.")
+        ACTIVE
     }
     
 }

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
@@ -368,6 +368,9 @@ public class JSONPart extends AJSONPartProvider {
         @JSONDescription("If set, this causes the gun to automatically reload from the vehicle's inventory when its ammo count hits 0.  Guns will prefer to reload the same ammo that was previously in the gun, and will only reload different (yet compatible) ammo if the old ammo is not found.")
         public boolean autoReload;
 
+        @JSONDescription("Whether this cun can lock on to targets, regardless of whether the loaded bullet is guided.")
+        public boolean canLockTargets;
+
         @JSONDescription("If set and true, then this gun part will be able to be held and fired from the player's hand.  All animations, and lighting applies here, so keep this in mind. If this is set, then handHeldNormalOffset and handHeldAimingOffset MUST be included!  Note that custom cameras will work when hand-held, but they will not be activated via the standard F5 cycling.  Instead, they will be activated when the player sneaks.  This is intended to allow for scopes and the like.")
         public boolean handHeld;
 

--- a/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
@@ -1708,6 +1708,10 @@ public final class LegacyCompatSystem {
         if (definition.bullet.damage == 0) {
             definition.bullet.damage = definition.bullet.diameter / 5F;
         }
+        //Make guided bullets default to active guidance
+        if (definition.bullet.guidanceType == null && definition.bullet.turnRate > 0) {
+            definition.bullet.guidanceType = JSONBullet.GuidanceType.ACTIVE;
+        }
 
         //Make rendering particle section for bullets for block hitting if it doesn't exist.
         if (definition.rendering == null || definition.rendering.particles == null) {


### PR DESCRIPTION
Adds Semi-Active Guidance for missiles, which means the gun firing must maintain its lock on a target for the bullet to guide to it. Once lock is broken off, guidance stops.
Adds Laser Guidance in the best way it can right now as BlockHitResults are limited to 200 blocks before the raytrace returns null.
Adds a LegacyCompat for guidanceType
