### PR TITLE
Fixes child parts always being interactable

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
@@ -339,7 +339,7 @@ public abstract class APart extends AEntityF_Multipart<JSONPart> {
 
     @Override
     public boolean canBeClicked() {
-        return entityOn.isVariableListTrue(placementDefinition.interactableVariables);
+        return entityOn.isVariableListTrue(placementDefinition.interactableVariables) ? entityOn.canBeClicked() : false;
     }
 
     /**

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
@@ -339,7 +339,7 @@ public abstract class APart extends AEntityF_Multipart<JSONPart> {
 
     @Override
     public boolean canBeClicked() {
-        return entityOn.isVariableListTrue(placementDefinition.interactableVariables) ? entityOn.canBeClicked() : false;
+        return entityOn.isVariableListTrue(placementDefinition.interactableVariables) && entityOn.canBeClicked();
     }
 
     /**


### PR DESCRIPTION
This fixes the bug where child parts are clickable even if the parent is not. Now the child parts will mirror the parent,