### PR TITLE
[PR] ForwardsDamageMultiplier + tweak for #1592

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/blocks/tileentities/instances/TileEntityDecor.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/blocks/tileentities/instances/TileEntityDecor.java
@@ -82,10 +82,10 @@ public class TileEntityDecor extends ATileEntityBase<JSONDecor> {
                 player.sendPacket(new PacketEntityGUIRequest(this, player, PacketEntityGUIRequest.EntityGUIType.TEXT_EDITOR));
             }
             else {
-           			setVariable(CLICKED_VARIABLE, 1);
+            		setVariable(CLICKED_VARIABLE, 1);
             		toggleVariable(ACTIVATED_VARIABLE);
             		InterfaceManager.packetInterface.sendToAllClients(new PacketEntityVariableSet(this, CLICKED_VARIABLE, 1));
-           			InterfaceManager.packetInterface.sendToAllClients(new PacketEntityVariableToggle(this, ACTIVATED_VARIABLE));
+            		InterfaceManager.packetInterface.sendToAllClients(new PacketEntityVariableToggle(this, ACTIVATED_VARIABLE));
             	 }
         } else if (definition.decor.type == DecorComponentType.SEAT) {
             setRider(player, true);

--- a/mccore/src/main/java/minecrafttransportsimulator/blocks/tileentities/instances/TileEntityDecor.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/blocks/tileentities/instances/TileEntityDecor.java
@@ -80,12 +80,13 @@ public class TileEntityDecor extends ATileEntityBase<JSONDecor> {
         } else if (!text.isEmpty()) {
             if (player.isHoldingItemType(ItemComponentType.WRENCH) && player.isSneaking()) {
                 player.sendPacket(new PacketEntityGUIRequest(this, player, PacketEntityGUIRequest.EntityGUIType.TEXT_EDITOR));
-            }	else {
-            setVariable(CLICKED_VARIABLE, 1);
-            toggleVariable(ACTIVATED_VARIABLE);
-            InterfaceManager.packetInterface.sendToAllClients(new PacketEntityVariableSet(this, CLICKED_VARIABLE, 1));
-            InterfaceManager.packetInterface.sendToAllClients(new PacketEntityVariableToggle(this, ACTIVATED_VARIABLE));
             }
+            else {
+           			setVariable(CLICKED_VARIABLE, 1);
+            		toggleVariable(ACTIVATED_VARIABLE);
+            		InterfaceManager.packetInterface.sendToAllClients(new PacketEntityVariableSet(this, CLICKED_VARIABLE, 1));
+           			InterfaceManager.packetInterface.sendToAllClients(new PacketEntityVariableToggle(this, ACTIVATED_VARIABLE));
+            	 }
         } else if (definition.decor.type == DecorComponentType.SEAT) {
             setRider(player, true);
         } else {

--- a/mccore/src/main/java/minecrafttransportsimulator/blocks/tileentities/instances/TileEntityDecor.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/blocks/tileentities/instances/TileEntityDecor.java
@@ -80,6 +80,11 @@ public class TileEntityDecor extends ATileEntityBase<JSONDecor> {
         } else if (!text.isEmpty()) {
             if (player.isHoldingItemType(ItemComponentType.WRENCH) && player.isSneaking()) {
                 player.sendPacket(new PacketEntityGUIRequest(this, player, PacketEntityGUIRequest.EntityGUIType.TEXT_EDITOR));
+            }	else {
+            setVariable(CLICKED_VARIABLE, 1);
+            toggleVariable(ACTIVATED_VARIABLE);
+            InterfaceManager.packetInterface.sendToAllClients(new PacketEntityVariableSet(this, CLICKED_VARIABLE, 1));
+            InterfaceManager.packetInterface.sendToAllClients(new PacketEntityVariableToggle(this, ACTIVATED_VARIABLE));
             }
         } else if (definition.decor.type == DecorComponentType.SEAT) {
             setRider(player, true);

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityBullet.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityBullet.java
@@ -357,7 +357,7 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
                                 if (hitPart.definition.generic.forwardsDamage || hitPart instanceof PartEngine) {
                                     if (!world.isClient()) {
                                         //Need to re-create damage object to use box on vehicle.  Otherwise, we'll attack the part.
-                                        damage = new Damage(damage.amount, null, gun, null, null);
+                                        damage = new Damage((hitPart.definition.generic.forwardsDamageMultiplier*damage.amount), null, gun, null, null);
                                         damage.setBullet(getItem());
                                         hitVehicle.attack(damage);
                                     }

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
@@ -99,7 +99,7 @@ public class JSONPart extends AJSONPartProvider {
         @JSONDescription("If true, this part will forward damage onto the vehicle it is on when hit by a bullet.  This will also cause the bullet to stop when it hits this part.  Engines ignore this behavior and always forward damage.")
         public boolean forwardsDamage;
 
-        @JSONDescription("The amount to multiply forwarded damage by, for more or less sensitive parts. Defaults to a whopping 1x multiplier if not defined.")
+        @JSONDescription("The multiplier for forwarded damage.")
         public double forwardsDamageMultiplier;
 
         @JSONDescription("If true, this part can be placed on the ground.  It will be placed axis-aligned when placed.")

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
@@ -99,6 +99,9 @@ public class JSONPart extends AJSONPartProvider {
         @JSONDescription("If true, this part will forward damage onto the vehicle it is on when hit by a bullet.  This will also cause the bullet to stop when it hits this part.  Engines ignore this behavior and always forward damage.")
         public boolean forwardsDamage;
 
+        @JSONDescription("The amount to multiply forwarded damage by, for more or less sensitive parts. Defaults to a whopping 1x multiplier if not defined.")
+        public double forwardsDamageMultiplier;
+
         @JSONDescription("If true, this part can be placed on the ground.  It will be placed axis-aligned when placed.")
         public boolean canBePlacedOnGround;
 

--- a/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
@@ -558,7 +558,7 @@ public final class LegacyCompatSystem {
         
         //While we're here in generic, check if we have forwardsDamageMultiplier defined and if not, lemon-grenade it until it's defined.
         if (definition.generic.forwardsDamageMultiplier == 0) {
-                definition.generic.forwardsDamageMultiplier = definition.generic.type.contains("engine") ? 4 : 1;//If this part is an engine, deal more damage to the vehicle by default (unless that FDM was defined, of course)
+                definition.generic.forwardsDamageMultiplier = 1;
             }
         
         //Move subParts to parts if we have them there.

--- a/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
@@ -555,7 +555,12 @@ public final class LegacyCompatSystem {
             definition.generic.useVehicleTexture = definition.general.useVehicleTexture;
             definition.general.useVehicleTexture = false;
         }
-
+        
+        //While we're here in generic, check if we have forwardsDamageMultiplier defined and if not, lemon-grenade it until it's defined.
+        if (definition.generic.forwardsDamageMultiplier == 0) {
+                definition.generic.forwardsDamageMultiplier = definition.generic.type.contains("engine") ? 4 : 1;//If this part is an engine, deal more damage to the vehicle by default (unless that FDM was defined, of course)
+            }
+        
         //Move subParts to parts if we have them there.
         if (definition.subParts != null) {
             definition.parts = definition.subParts;


### PR DESCRIPTION
ForwardsDamageMultiplier will, as the name implies, multiply damage forwarded by whatever it is defined as. 0.5 will deal half damage to the vehicle, 2 will do twice as much and 5 is right out. 
If not defined, LCs will set this to either 1 or 4, depending on whether the part isn't or is an engine. (The logic being that in (newer versions of) GTA, shooting the engine of a vehicle damages it much more than shooting the doors or body panels.)