### PR TITLE
Round out `acceleration` variable from -+0.025 to 0 in order to mitigate negative-positive jumping

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
@@ -797,7 +797,7 @@ public class EntityVehicleF_Physics extends AEntityVehicleE_Powered {
             case ("speed_factor"):
                 return speedFactor;
             case ("acceleration"):
-                return motion.length() - prevMotion.length();
+                return Math.round((motion.length() - prevMotion.length()) * 1000.0) / 1000.0;
             case ("road_angle_front"):
                 return frontFollower != null ? frontFollower.getCurrentYaw() - orientation.angles.y : 0;
             case ("road_angle_rear"):

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
@@ -797,7 +797,7 @@ public class EntityVehicleF_Physics extends AEntityVehicleE_Powered {
             case ("speed_factor"):
                 return speedFactor;
             case ("acceleration"):
-                return Math.round((motion.length() - prevMotion.length()) * 1000.0) / 1000.0;
+                return Math.round((motion.length() - prevMotion.length()) * 40.0) / 40.0;
             case ("road_angle_front"):
                 return frontFollower != null ? frontFollower.getCurrentYaw() - orientation.angles.y : 0;
             case ("road_angle_rear"):

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
@@ -797,7 +797,8 @@ public class EntityVehicleF_Physics extends AEntityVehicleE_Powered {
             case ("speed_factor"):
                 return speedFactor;
             case ("acceleration"):
-                return Math.round((motion.length() - prevMotion.length()) * 40.0) / 40.0;
+                double acceleration = motion.length() - prevMotion.length();
+                return acceleration > 0.025 || acceleration < -0.025 ? acceleration : 0;
             case ("road_angle_front"):
                 return frontFollower != null ? frontFollower.getCurrentYaw() - orientation.angles.y : 0;
             case ("road_angle_rear"):


### PR DESCRIPTION
This freakin' thing has made me lose my mind for the LAST time.
No longer will I concede with making the translation or rotation guided by this variable smaller, nor hath I the patience to find just the right amount to dampen this variable by.
This god-forsaken value jumping padded by more 0's than π itself ends here, `acceleration` variable! I win!! 
![image](https://github.com/DonBruce64/MinecraftTransportSimulator/assets/53581325/fb701793-bded-4f6a-959b-8ab578daee6b)

tl;dr Rounding the `acceleration` so it doesn't constantly switch between positive and negative values, which doesn't play well with most uses for this variable