### PR TITLE
Adds `gun_ammo_count_reloading`

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
@@ -1176,6 +1176,8 @@ public class PartGun extends APart {
                 return reloadTimeRemaining > 0 ? 1 : 0;
             case ("gun_ammo_count"):
                 return bulletsLeft;
+            case ("gun_ammo_count_reloading"):
+                return reloadingBullet.definition.bullet.quantity;
             case ("gun_ammo_percent"):
                 return bulletsLeft / definition.gun.capacity;
             case ("gun_active_muzzlegroup"):


### PR DESCRIPTION
Adds `gun_ammo_count_reloading` for checking the ammo count of whichever bullet is being loaded into the gun

Handy when used alongside VMs for different magazine models