### PR TITLE
Adds `random_flip` variable, based on world time

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
@@ -807,6 +807,8 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
                 return world.getTime();
             case ("random"):
                 return Math.random();
+            case ("random_flip"):
+                return (world.getTime() % 2 == 0) ? 1 : 0;
             case ("rain_strength"):
                 return (int) world.getRainStrength(position);
             case ("rain_sin"): {

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
@@ -808,7 +808,7 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
             case ("random"):
                 return Math.random();
             case ("random_flip"):
-                return Math.floor(Math.random() * 1.99);
+                return Math.random() < 0.5 ? 0 : 1;
             case ("rain_strength"):
                 return (int) world.getRainStrength(position);
             case ("rain_sin"): {

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
@@ -808,7 +808,7 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
             case ("random"):
                 return Math.random();
             case ("random_flip"):
-                return (world.getTime() % 2 == 0) ? 1 : 0;
+                return Math.floor(Math.random() * 1.99);
             case ("rain_strength"):
                 return (int) world.getRainStrength(position);
             case ("rain_sin"): {


### PR DESCRIPTION
Unfortunately means this variable freezes up when the `doDaylightCycle` gamerule is set to false, but I'd generally assume that shouldn't be an issue as the worst case scenario involves getting the same result each time. 

Useful for defining a random chance between one set of conditionalDefaultParts or the other. Examples: setting a normal defaultPart along with one CDP to switch between the two, or not having a DP defined for a 50/50 chance of getting that part or not.