### PR TITLE
Fixed crash caused by referencing `gun_ammo_count_reloading` on a gun that's never been reloaded before

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
@@ -1177,7 +1177,9 @@ public class PartGun extends APart {
             case ("gun_ammo_count"):
                 return bulletsLeft;
             case ("gun_ammo_count_reloading"):
-                return reloadingBullet.definition.bullet.quantity;
+                return reloadTimeRemaining > 0 ? reloadingBullet.definition.bullet.quantity : 0; //EEEEVERYTHING YOU KNOW IS WRONG, BLACK IS WHITE UP IS DOWN AND INTS CAN'T 'null'!!! -cbc
+                //I would think that ideally this should've looked like the following, but apparently that's not actually possible, nor was it the solution anyways.
+                //return reloadingBullet.definition.bullet.quantity != null ? 1 : 0;
             case ("gun_ammo_percent"):
                 return bulletsLeft / definition.gun.capacity;
             case ("gun_active_muzzlegroup"):

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartGun.java
@@ -1177,9 +1177,7 @@ public class PartGun extends APart {
             case ("gun_ammo_count"):
                 return bulletsLeft;
             case ("gun_ammo_count_reloading"):
-                return reloadTimeRemaining > 0 ? reloadingBullet.definition.bullet.quantity : 0; //EEEEVERYTHING YOU KNOW IS WRONG, BLACK IS WHITE UP IS DOWN AND INTS CAN'T 'null'!!! -cbc
-                //I would think that ideally this should've looked like the following, but apparently that's not actually possible, nor was it the solution anyways.
-                //return reloadingBullet.definition.bullet.quantity != null ? 1 : 0;
+                return reloadingBullet != null ? reloadingBullet.definition.bullet.quantity : 0;
             case ("gun_ammo_percent"):
                 return bulletsLeft / definition.gun.capacity;
             case ("gun_active_muzzlegroup"):


### PR DESCRIPTION
\*sigh\* Should've caught and fixed this _before_ 22.12.0 released, not after.