### PR TITLE
Allowed constantValues to be defined on a part slot

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/APart.java
@@ -163,6 +163,11 @@ public abstract class APart extends AEntityF_Multipart<JSONPart> {
         if (definition.generic.activeAnimations != null) {
             internalActiveSwitchbox = new AnimationSwitchbox(this, definition.generic.activeAnimations, null);
         }
+
+        //Add parent constants.
+        if (placementDefinition.constantValues != null) {
+            variables.putAll(placementDefinition.constantValues);
+        }
     }
 
     @Override

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPartDefinition.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPartDefinition.java
@@ -2,6 +2,7 @@ package minecrafttransportsimulator.jsondefs;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import minecrafttransportsimulator.baseclasses.Point3D;
 import minecrafttransportsimulator.baseclasses.RotationMatrix;
@@ -144,6 +145,9 @@ public class JSONPartDefinition {
 
     @JSONDescription("A listing of animation objects for determining if this part is active.  Leaving this blank will make for a part that is always active.  Visibility transforms will turn the part on and off.  Inhibitor and activator transforms may be used in conjunction with these for advanced on/off logic.  The exact thing that an 'active' part does depends on the part.  Effectors only effect when they are active.  Guns can only be used when active.  Seats can only be sat in when active.  etc.  Note that this does NOT block the placement of the part or interaction.  That logic is for the linkedVariables.")
     public List<JSONAnimationDefinition> activeAnimations;
+
+    @JSONDescription("A mapping of constant-value variable names to values.  These variables will be added into the listing of active variables the moment the JSON is loaded. Note that they CAN be over-written if referenced as such, so keep this in mind. If defined here (in the part slot), will override the parent CVs.")
+    public Map<String, Double> constantValues;
 
     @Deprecated
     public JSONPartDefinition additionalPart;


### PR DESCRIPTION
When a constantValues list is defined on a part slot, it is appended to that part's internal constantValues.