### PR TITLE
steeringForceFactor + steeringForceIgnoresSpeed

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/AEntityVehicleD_Moving.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/AEntityVehicleD_Moving.java
@@ -354,7 +354,7 @@ abstract class AEntityVehicleD_Moving extends AEntityVehicleC_Colliding {
                     vectorDelta = 180 + vectorDelta;
                 }
             }
-            if (this.towedByConnection == null) {
+            /*if (this.towedByConnection == null) {
                 double overSteerForce = Math.max(velocity / 4, 1);
                 if (definition.motorized.overSteerAccel != 0) {
                     weightTransfer += ((motion.dotProduct(motion, false) - prevMotion.dotProduct(prevMotion, false)) * weightTransfer) * currentOverSteer;
@@ -367,7 +367,7 @@ abstract class AEntityVehicleD_Moving extends AEntityVehicleC_Colliding {
                     weightTransfer = currentOverSteer;
                 }
                 rotation.angles.y += crossProduct.y * weightTransfer + (Math.abs(crossProduct.y) * -currentUnderSteer * turningForce) * overSteerForce;
-            }
+            }*/
 
             //If we are offset, adjust our angle.
             if (Math.abs(vectorDelta) > 0.001) {
@@ -519,14 +519,14 @@ abstract class AEntityVehicleD_Moving extends AEntityVehicleC_Colliding {
                 //This is opposite of the torque-based forces for control surfaces.
                 double turningForce = steeringAngle / turningDistance;
                 //Decrease force by the speed of the vehicle.  If we are going fast, we can't turn as quickly.
-                if (groundVelocity > 0.35D) {
-                    turningForce *= Math.pow(0.3F, (groundVelocity * (1 - currentDownForce) - 0.35D));
-                }
+                /*if (groundVelocity > 0.35D) {
+                //    turningForce *= Math.pow(0.3F, (groundVelocity * (1 - currentDownForce) - 0.35D));
+                }*/
                 //Calculate the force the steering produces.  Start with adjusting the steering factor by the ground velocity.
                 //This is because the faster we go the quicker we need to turn to keep pace with the vehicle's movement.
                 //We need to take speed-factor into account here, as that will make us move different lengths per tick.
                 //Finally, we need to reduce this by a constant to get "proper" force..
-                return turningForce * groundVelocity * (speedFactor / 0.35D) / 2D;
+                return turningForce * (groundVelocity * (currentOverSteer + 1)) * (speedFactor / 0.35D) / 2D;
             }
         }
         return 0;

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/AEntityVehicleD_Moving.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/AEntityVehicleD_Moving.java
@@ -63,6 +63,7 @@ abstract class AEntityVehicleD_Moving extends AEntityVehicleC_Colliding {
     private boolean updateGroundDevicesRequest;
     private int lastBlockCollisionBoxesCount;
     public double groundVelocity;
+    public double turningForce;
     public double weightTransfer = 0;
     public final RotationMatrix rotation = new RotationMatrix();
     private final IWrapperPlayer placingPlayer;
@@ -441,7 +442,7 @@ abstract class AEntityVehicleD_Moving extends AEntityVehicleC_Colliding {
      * Sign of returned value indicates which direction entity should yaw.
      * A 0 value indicates no yaw change.
      */
-    protected double getTurningForce() {
+    private double getTurningForce() {
         skidSteerActive = false;
         double steeringAngle = getSteeringAngle() * 45;
 
@@ -519,7 +520,7 @@ abstract class AEntityVehicleD_Moving extends AEntityVehicleC_Colliding {
                 //Steering force is initially is the value of the angle, divided by the distance to the wheels.
                 //This means tighter turning for shorter-wheelbase vehicles and more input.
                 //This is opposite of the torque-based forces for control surfaces.
-                double turningForce = steeringAngle / turningDistance;
+                turningForce = steeringAngle / turningDistance;
                 //Decrease force by the speed of the vehicle.  If we are going fast, we can't turn as quickly.
                 if (groundVelocity > 0.35D && currentSteeringForceIgnoresSpeed == 0) {
                     turningForce *= Math.pow(0.3F, (groundVelocity * (1 - currentSteeringForceFactor) - 0.35D));

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/AEntityVehicleD_Moving.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/AEntityVehicleD_Moving.java
@@ -424,7 +424,7 @@ abstract class AEntityVehicleD_Moving extends AEntityVehicleC_Colliding {
      * device calculations should be applied due to said devices being in
      * contact with the ground.
      */
-    protected float getSkiddingForce() {
+    private float getSkiddingForce() {
         float skiddingFactor = 0;
         //First check grounded ground devices.
         for (PartGroundDevice groundDevice : groundDeviceCollective.groundedGroundDevices) {
@@ -530,7 +530,7 @@ abstract class AEntityVehicleD_Moving extends AEntityVehicleC_Colliding {
                 //This is because the faster we go the quicker we need to turn to keep pace with the vehicle's movement.
                 //We need to take speed-factor into account here, as that will make us move different lengths per tick.
                 //Finally, we need to reduce this by a constant to get "proper" force..
-                return turningForce * (groundVelocity * (currentOverSteer + 1)) * (speedFactor / 0.35D) / 2D;
+                return turningForce * groundVelocity * (speedFactor / 0.35D) / 2D;
             }
         }
         return 0;

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/AEntityVehicleD_Moving.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/AEntityVehicleD_Moving.java
@@ -69,7 +69,7 @@ abstract class AEntityVehicleD_Moving extends AEntityVehicleC_Colliding {
 
     //Properties
     @ModifiedValue
-    public float currentSteeringForceIgnoration;
+    public float currentSteeringForceIgnoresSpeed;
     @ModifiedValue
     public float currentSteeringForceFactor;
     @ModifiedValue
@@ -521,9 +521,9 @@ abstract class AEntityVehicleD_Moving extends AEntityVehicleC_Colliding {
                 //This is opposite of the torque-based forces for control surfaces.
                 double turningForce = steeringAngle / turningDistance;
                 //Decrease force by the speed of the vehicle.  If we are going fast, we can't turn as quickly.
-                if (groundVelocity > 0.35D && currentSteeringForceIgnoration == 0) {
+                if (groundVelocity > 0.35D && currentSteeringForceIgnoresSpeed == 0) {
                     turningForce *= Math.pow(0.3F, (groundVelocity * (1 - currentSteeringForceFactor) - 0.35D));
-                } else if (currentSteeringForceIgnoration != 0) {
+                } else if (currentSteeringForceIgnoresSpeed != 0) {
                     turningForce *= currentSteeringForceFactor;
                 }
                 //Calculate the force the steering produces.  Start with adjusting the steering factor by the ground velocity.

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
@@ -272,7 +272,8 @@ public class EntityVehicleF_Physics extends AEntityVehicleE_Powered {
         currentDragCoefficient = definition.motorized.dragCoefficient;
         currentBallastVolume = definition.motorized.ballastVolume;
         currentWaterBallastFactor = definition.motorized.waterBallastFactor;
-        currentDownForce = definition.motorized.downForce;
+        currentSteeringForceIgnoration = definition.motorized.steeringForceIgnoresSpeed ? 1 : 0;
+        currentSteeringForceFactor = definition.motorized.steeringForceFactor;
         currentBrakingFactor = definition.motorized.brakingFactor;
         currentOverSteer = definition.motorized.overSteer;
         currentUnderSteer = definition.motorized.underSteer;
@@ -312,8 +313,11 @@ public class EntityVehicleF_Physics extends AEntityVehicleE_Powered {
                     case "waterBallastFactor":
                         currentWaterBallastFactor = adjustVariable(modifier, currentWaterBallastFactor);
                         break;
-                    case "downForce":
-                        currentDownForce = adjustVariable(modifier, currentDownForce);
+                    case "steeringForceIgnoresSpeed":
+                    	currentSteeringForceIgnoration = adjustVariable(modifier, currentSteeringForceIgnoration);
+                        break;
+                    case "steeringForceFactor":
+                        currentSteeringForceFactor = adjustVariable(modifier, currentSteeringForceFactor);
                         break;
                     case "brakingFactor":
                         currentBrakingFactor = adjustVariable(modifier, currentBrakingFactor);

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
@@ -881,6 +881,9 @@ public class EntityVehicleF_Physics extends AEntityVehicleE_Powered {
                 return (rotation.angles.x) / 0.15F * 25F;
             case ("slip"):
                 return 75 * sideVector.dotProduct(normalizedVelocityVector, true);
+            case ("slip_understeer"):
+                double turningForce = Math.max(0, Math.min(1, Math.abs(getTurningForce()) / 10));
+                return getSteeringAngle() * (1 - turningForce);
             case ("gear_present"):
                 return definition.motorized.gearSequenceDuration != 0 ? 1 : 0;
             case ("gear_moving"):

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
@@ -272,7 +272,7 @@ public class EntityVehicleF_Physics extends AEntityVehicleE_Powered {
         currentDragCoefficient = definition.motorized.dragCoefficient;
         currentBallastVolume = definition.motorized.ballastVolume;
         currentWaterBallastFactor = definition.motorized.waterBallastFactor;
-        currentSteeringForceIgnoration = definition.motorized.steeringForceIgnoresSpeed ? 1 : 0;
+        currentSteeringForceIgnoresSpeed = definition.motorized.steeringForceIgnoresSpeed ? 1 : 0;
         currentSteeringForceFactor = definition.motorized.steeringForceFactor;
         currentBrakingFactor = definition.motorized.brakingFactor;
         currentOverSteer = definition.motorized.overSteer;
@@ -314,7 +314,7 @@ public class EntityVehicleF_Physics extends AEntityVehicleE_Powered {
                         currentWaterBallastFactor = adjustVariable(modifier, currentWaterBallastFactor);
                         break;
                     case "steeringForceIgnoresSpeed":
-                    	currentSteeringForceIgnoration = adjustVariable(modifier, currentSteeringForceIgnoration);
+                    	currentSteeringForceIgnoresSpeed = adjustVariable(modifier, currentSteeringForceIgnoresSpeed);
                         break;
                     case "steeringForceFactor":
                         currentSteeringForceFactor = adjustVariable(modifier, currentSteeringForceFactor);

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
@@ -882,8 +882,7 @@ public class EntityVehicleF_Physics extends AEntityVehicleE_Powered {
             case ("slip"):
                 return 75 * sideVector.dotProduct(normalizedVelocityVector, true);
             case ("slip_understeer"):
-                double turningForce = Math.max(0, Math.min(1, Math.abs(getTurningForce()) / 10));
-                return getSteeringAngle() * (1 - turningForce);
+                return getSteeringAngle() * (1 - Math.max(0, Math.min(1, Math.abs(getTurningForce()) / 10)));
             case ("gear_present"):
                 return definition.motorized.gearSequenceDuration != 0 ? 1 : 0;
             case ("gear_moving"):

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
@@ -882,7 +882,7 @@ public class EntityVehicleF_Physics extends AEntityVehicleE_Powered {
             case ("slip"):
                 return 75 * sideVector.dotProduct(normalizedVelocityVector, true);
             case ("slip_understeer"):
-                return getSteeringAngle() * (1 - Math.max(0, Math.min(1, Math.abs(getTurningForce()) / 10)));
+                return getSteeringAngle() * (1 - Math.max(0, Math.min(1, Math.abs(turningForce) / 10)));
             case ("gear_present"):
                 return definition.motorized.gearSequenceDuration != 0 ? 1 : 0;
             case ("gear_moving"):

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONVehicle.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONVehicle.java
@@ -94,9 +94,12 @@ public class JSONVehicle extends AJSONPartProvider {
         @JSONDescription("This parameter is optional.  If included, and set to anything besides 0, the vehicle will be considered to have landing gear, with the transition between up and down having the passed-in duration.  Most of the time you'll be using your own animations, so this is more just to make the gear lever appear in the panel and to tell MTS how to change the light states for it.")
         public int gearSequenceDuration;
 
+        @JSONDescription("Set this to true if you want vehicles to ignore speed when accounting for steering force. Works in tandem with steeringForceFactor.")
+        public boolean steeringForceIgnoresSpeed;
+
         @ModifiableValue
-        @JSONDescription("The amount of steering force output for cars. The value functions between 0 and 1, with 1 being full steering force at any speed and 0 being normal MTS steering force.")
-        public float downForce;
+        @JSONDescription("The amount of steering force output for cars, either based on current speed or as a whole. The value generally functions between 0 and 1 when steeringForceIgnoresSpeed is disabled, with 1 acting as full steering force at any speed whilst 0 results in normal MTS steering force. However if steeringForceIgnoresSpeed is enabled this variable defines the vehicle's steering force output regardless of its current forward velocity.")
+        public float steeringForceFactor;
 
         @ModifiableValue
         @JSONDescription("A value dictating the oversteer force of a vehicle when skidding.")
@@ -201,6 +204,8 @@ public class JSONVehicle extends AJSONPartProvider {
         public boolean isFrontWheelDrive;
         @Deprecated
         public boolean isRearWheelDrive;
+        @Deprecated
+        public float downForce;
         @Deprecated
         public String hornSound;
         @Deprecated

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONVehicle.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONVehicle.java
@@ -94,11 +94,11 @@ public class JSONVehicle extends AJSONPartProvider {
         @JSONDescription("This parameter is optional.  If included, and set to anything besides 0, the vehicle will be considered to have landing gear, with the transition between up and down having the passed-in duration.  Most of the time you'll be using your own animations, so this is more just to make the gear lever appear in the panel and to tell MTS how to change the light states for it.")
         public int gearSequenceDuration;
 
-        @JSONDescription("Set this to true if you want vehicles to ignore speed when accounting for steering force. Works in tandem with steeringForceFactor.")
+        @JSONDescription("Set this to true if you want vehicles to ignore speed, and instead call from steeringForceFactor for their current steering force. Otherwise by default, vehicles will gradually lose their ability to steer as they gain speed.")
         public boolean steeringForceIgnoresSpeed;
 
         @ModifiableValue
-        @JSONDescription("The amount of steering force output for cars, either based on current speed or as a whole. The value generally functions between 0 and 1 when steeringForceIgnoresSpeed is disabled, with 1 acting as full steering force at any speed whilst 0 results in normal MTS steering force. However if steeringForceIgnoresSpeed is enabled this variable defines the vehicle's steering force output regardless of its current forward velocity.")
+        @JSONDescription("The amount of steering force output for cars, based either on current speed or as a whole, dependent on steeringForceIgnoresSpeed for choosing between such behavior. By default a value of 0 results in default MTS steering forces, while 1 allows full steering force at any speed. However if steeringForceIgnoresSpeed is set to true then 0 will result in no steering force at any speed, with 1 otherwise resulting in the same handling.")
         public float steeringForceFactor;
 
         @ModifiableValue

--- a/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
@@ -361,9 +361,9 @@ public final class LegacyCompatSystem {
             definition.motorized.hasCruiseControl = false;
         }
 
-        //If downforce is greater than 1, set it to 0.5 to prevent spinny vehicles.
-        if (definition.motorized.downForce > 1) {
-            definition.motorized.downForce = 0.5F;
+        //Change downForce's name to steeringForceFactor
+        if (definition.motorized.downForce != 0) {
+            definition.motorized.steeringForceFactor = definition.motorized.downForce;
         }
 
         //Add hookup variables if we are a trailer and don't have them.

--- a/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/packloading/LegacyCompatSystem.java
@@ -364,6 +364,7 @@ public final class LegacyCompatSystem {
         //Change downForce's name to steeringForceFactor
         if (definition.motorized.downForce != 0) {
             definition.motorized.steeringForceFactor = definition.motorized.downForce;
+            definition.motorized.downForce = 0;
         }
 
         //Add hookup variables if we are a trailer and don't have them.


### PR DESCRIPTION
### This PR does four significant things:
- downForce has been renamed to steeringForceFactor, otherwise retaining its same functionality\* _(\*See below)_
- steeringForceIgnoresSpeed, switches handling behavior to ignore the vehicle's current velocity. 
- When above boolean is true, ~~downForce~~ steeringForceFactor directly controls the vehicle's turningForce instead of it being influenced by speed and steeringForceFactor.
- slip_understeer, current steering angle - turningForce (if the vehicle cannot turn at all this returns 1.0, otherwise everything between 0.0)

### But why?
Some pack authors may find the current behavior of downForce/overSteer/underSteer to offer less control over their vehicle's handling than wished. This is especially noticeable because at low speeds, downForce has little to no effect on vehicle handling. However this pull request seeks to alleviate that by retaining this behavior by default whilst offering an alternative.
As ~~downForce~~ steeringForceFactor can be variableModified, this results in more customizable vehicle behavior through the use of clever VMs.

### Other stuff
downForce has technically been deprecated, however it is immediately LC'ed to steeringForceFactor. As there is no change in functionality when steeringForceIgnoresSpeed is false, this has no effect on any packs to my knowledge.
Demonstrational Video

https://github.com/DonBruce64/MinecraftTransportSimulator/assets/53581325/dfe40d9d-b263-4e3a-b672-5b83441816fc

\*sigh\* Point, not ponit.