### PR TITLE
Prevent Welcome to MTS VERSION Error

### DIFF
--- a/mcinterfaceforge1165/src/main/java/mcinterface1165/InterfaceLoader.java
+++ b/mcinterfaceforge1165/src/main/java/mcinterface1165/InterfaceLoader.java
@@ -87,7 +87,7 @@ public class InterfaceLoader {
             new InterfaceManager(MODID, gameDirectory, new InterfaceCore(), new InterfacePacket(), null, null, null, null);
         }
 
-        InterfaceManager.coreInterface.logError("Welcome to MTS VERSION: " + MODVER);
+       InterfaceLoader.LOGGER.log("Welcome to MTS VERSION: " + MODVER);
 
         //Parse packs
         ConfigSystem.loadFromDisk(new File(gameDirectory, "config"), isClient);


### PR DESCRIPTION
I forgot about 1.16.5 when I did this for 1.12.2.

Fixes MTS creating a error every startup