### PR TITLE
Patch 1

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
@@ -111,6 +111,7 @@ public class PartEngine extends APart {
     private double prevDriveshaftRotation;
     private double currentJetPowerFactor;
     private double currentBypassRatio;
+    private double currentThrustVectorMultiplier;
     private final List<PartGroundDevice> linkedWheels = new ArrayList<>();
     private final List<PartGroundDevice> drivenWheels = new ArrayList<>();
     private final List<PartPropeller> linkedPropellers = new ArrayList<>();
@@ -784,7 +785,7 @@ public class PartEngine extends APart {
         currentWinddownRate = definition.engine.engineWinddownRate;
         currentJetPowerFactor = definition.engine.jetPowerFactor;
         currentBypassRatio = definition.engine.bypassRatio;
-
+        currentThrustVectorMultiplier = definition.engine.thrustVectorMultiplier;
 
         //Adjust current variables to modifiers, if any exist.
         if (definition.variableModifiers != null) {
@@ -852,6 +853,9 @@ public class PartEngine extends APart {
                         break;
                     case "bypassRatio":
                         currentBypassRatio = adjustVariable(modifier,(float) currentBypassRatio);
+                        break;
+                        case "thrustVectorMultiplier":
+                    currentThrustVectorMultiplier = adjustVariable(modifier,(float) currentThrustVectorMultiplier);
                         break;
                     default:
                         setVariable(modifier.variable, adjustVariable(modifier, (float) getVariable(modifier.variable)));
@@ -963,6 +967,8 @@ public class PartEngine extends APart {
                 return hours;
             case ("engine_bypass_ratio"):
                 return currentBypassRatio;
+            case ("engine_thrustVectorMultiplier"):
+                return currentThrustVectorMultiplier;
             case ("engine_jet_power_factor"):
                 return currentJetPowerFactor;
         }
@@ -1305,7 +1311,7 @@ public class PartEngine extends APart {
             engineForce.set(engineAxisVector).scale(thrust);
             force.add(engineForce);
             engineForce.reOrigin(vehicleOn.orientation);
-            torque.add(localOffset.crossProduct(engineForce));
+            torque.add(localOffset.crossProduct(engineForce).scale(currentThrustVectorMultiplier));
         }
         return engineForceValue;
     }

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONPart.java
@@ -214,6 +214,9 @@ public class JSONPart extends AJSONPartProvider {
         @JSONDescription("Used only with jetPowerFactor for jet thrust calculations.  Higher bypass ratio engines will have better power when turning fast, and will allow for lower fuel consumptions, but will also have a lower top-speed.")
         public float bypassRatio;
 
+        @JSONDescription("Changes the amount of rotational (AKA Thrust Vectoring) force jet engines apply to the vehicle theyre placed on. Useful for aircrafts that have large engines that are off center")
+        public float thrustVectorMultiplier;
+
         @JSONDescription("This is a constant ratio that will be used for any propellers attached to this engine, and will override the value in gearRatios.  Useful when you want to gear-down a propeller on a vehicle that's normally land-bound.")
         public float propellerRatio;
 


### PR DESCRIPTION
big thanks to conman for helping me fix up my jank ass code cause he knows java and i dont
Adjustable thrust vectoring value for engine parts, as thrust changes to mts physics system with thrust vectoring has proven to be a headache for me and other PAs, especially those from GAP. There are no LCs for defaulting the value to 1.0, as a majority of people who ive asked in mts were in favor of defaulting the value to 0 when thrust vectoring is not found. Also, this jet thrust vectoring is VMable Please let me know in MTS if theres any issues or code oversights.