### PR TITLE
solve 1.12.2 DeadZone problem

### DIFF
--- a/mcinterfaceforge1122/src/main/java/mcinterface1122/InterfaceInput.java
+++ b/mcinterfaceforge1122/src/main/java/mcinterface1122/InterfaceInput.java
@@ -244,6 +244,8 @@ public class InterfaceInput implements IInterfaceInput {
             //Make sure we're not calling this on non-axis.
             if (joystickMap.containsKey(joystickName)) {
                 if (isJoystickComponentAxis(joystickName, index)) {
+                    //lwjgl might add a default DeadZone for input so just disable it before using
+                    joystickMap.get(joystickName).setDeadZone(index,0);
                     joystickMap.get(joystickName).poll();
                     return joystickMap.get(joystickName).getAxisValue(index);
                 } else {


### PR DESCRIPTION
lwjgl adds a default deadzone for input, disable it to avoid problem:
![2024-09-13_08 02 24](https://github.com/user-attachments/assets/c4a25b6d-ab3e-4acd-a292-61c5f28750de)
![2024-09-13_08 06 53](https://github.com/user-attachments/assets/0d80d03e-ffed-4a58-87a2-df9f98cedc8a)
