### PR TITLE
activeAnimations for NORMAL and ROCKET type engines

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
@@ -474,12 +474,15 @@ public class PartEngine extends APart {
                             if (isInLiquid()) {
                                 stallEngine(Signal.DROWN);
                                 InterfaceManager.packetInterface.sendToAllClients(new PacketPartEngine(this, Signal.DROWN));
-                            } else if (!vehicleOn.isCreative && ConfigSystem.settings.general.fuelUsageFactor.value != 0 && vehicleOn.fuelTank.getFluidLevel() == 0) {
+                            } else  if (!vehicleOn.isCreative && ConfigSystem.settings.general.fuelUsageFactor.value != 0 && vehicleOn.fuelTank.getFluidLevel() == 0) {
                                 stallEngine(Signal.FUEL_OUT);
                                 InterfaceManager.packetInterface.sendToAllClients(new PacketPartEngine(this, Signal.FUEL_OUT));
                             } else if (rpm < stallRPMVar.currentValue) {
                                 stallEngine(Signal.TOO_SLOW);
                                 InterfaceManager.packetInterface.sendToAllClients(new PacketPartEngine(this, Signal.TOO_SLOW));
+                            } else if (!isActive) {
+                                stallEngine(Signal.INACTIVE);
+                                InterfaceManager.packetInterface.sendToAllClients(new PacketPartEngine(this, Signal.INACTIVE));
                             }
                         }
                     } else {
@@ -496,7 +499,7 @@ public class PartEngine extends APart {
                         //have the ability to engage a starter.
                         if (rpm >= startRPMVar.currentValue && !world.isClient() && !vehicleOn.outOfHealth) {
                             if (vehicleOn.isCreative || ConfigSystem.settings.general.fuelUsageFactor.value == 0 || vehicleOn.fuelTank.getFluidLevel() > 0) {
-                                if (!isInLiquid() && magnetoVar.isActive) {
+                                if (isActive && !isInLiquid() && magnetoVar.isActive) {
                                     startEngine();
                                     InterfaceManager.packetInterface.sendToAllClients(new PacketPartEngine(this, Signal.START));
                                 }

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
@@ -513,12 +513,12 @@ public class PartEngine extends APart {
                     if (running) {
                         //Remove fuel, and if we don't have any, turn ourselves off.
                         rocketFuelUsed += getTotalFuelConsumption();
-                        if (rocketFuelUsed >= definition.engine.rocketFuel) {
+                        if (!isActive || rocketFuelUsed >= definition.engine.rocketFuel) {
                             running = false;
                         }
                     } else {
                         //If the magneto comes on, and we have fuel, ignite.
-                        if (magnetoVar.isActive && rocketFuelUsed < definition.engine.rocketFuel) {
+                        if (isActive && magnetoVar.isActive && rocketFuelUsed < definition.engine.rocketFuel) {
                             running = true;
                         }
                     }

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
@@ -474,7 +474,7 @@ public class PartEngine extends APart {
                             if (isInLiquid()) {
                                 stallEngine(Signal.DROWN);
                                 InterfaceManager.packetInterface.sendToAllClients(new PacketPartEngine(this, Signal.DROWN));
-                            } else  if (!vehicleOn.isCreative && ConfigSystem.settings.general.fuelUsageFactor.value != 0 && vehicleOn.fuelTank.getFluidLevel() == 0) {
+                            } else if (!vehicleOn.isCreative && ConfigSystem.settings.general.fuelUsageFactor.value != 0 && vehicleOn.fuelTank.getFluidLevel() == 0) {
                                 stallEngine(Signal.FUEL_OUT);
                                 InterfaceManager.packetInterface.sendToAllClients(new PacketPartEngine(this, Signal.FUEL_OUT));
                             } else if (rpm < stallRPMVar.currentValue) {


### PR DESCRIPTION
This feature previously worked for normal engines, but was lost in the process of adding electric and magic types (and probably before that, so it's my fault for not realizing much, much sooner)
It *does* work for electric and magic, so these were the only types that needed fixing

Useful for UNU's motors when they are disassembled, with this change they can just become inactive instead of forcibly disabling their magnetos