### PR TITLE
Mr.Mulles updated crafting recipes

### DIFF
--- a/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/enginebench.json
+++ b/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/enginebench.json
@@ -3,7 +3,7 @@
     "pattern": [
         "aaa",
         "bca",
-        " dd"
+        " ed"
     ],
     "key": {
         "a": {
@@ -19,6 +19,9 @@
         },
         "d": {
             "item": "minecraft:iron_block"
+        },
+        "e": {
+            "item": "minecraft:heavy_weighted_pressure_plate"
         }
     },
     "result": {

--- a/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/fuelpump.json
+++ b/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/fuelpump.json
@@ -1,29 +1,28 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
-        "cdc",
-        "eee"
+        " a ",
+        "bcd",
+        "ece"
     ],
     "key": {
-        "a": {
+    	"a": {
+            "item": "minecraft:glass_pane"
+        },
+        "b": {
             "type": "forge:ore_dict",
             "ore": "dyeRed"
         },
-        "b": {
-            "item": "minecraft:glass_pane"
-        },
         "c": {
-            "type": "forge:ore_dict",
-            "ore": "dyeBlack"
+            "item": "minecraft:bucket"
         },
         "d": {
-            "type": "forge:ore_dict",
-            "ore": "ingotIron"
+            "item": "mts:mts.fuelhose",
+            "data": 0
         },
         "e": {
-            "item": "minecraft:stone_slab",
-            "data": 0
+            "type": "forge:ore_dict",
+            "ore": "ingotIron"
         }
     },
     "result": {

--- a/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/gunbench.json
+++ b/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/gunbench.json
@@ -3,7 +3,7 @@
     "pattern": [
         "   ",
         "abc",
-        "dad"
+        "ccc"
     ],
     "key": {
         "a": {
@@ -14,11 +14,7 @@
         },
         "c": {
             "type": "forge:ore_dict",
-            "ore": "dyeRed"
-        },
-        "d": {
-            "type": "forge:ore_dict",
-            "ore": "dyeGreen"
+            "ore": "ingotIron"
         }
     },
     "result": {

--- a/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/handbook_car.json
+++ b/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/handbook_car.json
@@ -1,23 +1,17 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        " a ",
-        "cbc",
-        " d "
+        "   ",
+        " ab",
+        "   "
     ],
     "key": {
         "a": {
-            "item": "minecraft:feather"
-        },
-        "b": {
             "item": "minecraft:book"
         },
-        "c": {
-            "type": "forge:ore_dict",
-            "ore": "dyeBlack"
-        },
-        "d": {
-            "item": "minecraft:paper"
+        "b": {
+			"item": "mts:mts.key",
+            "data": 0
         }
     },
     "result": {

--- a/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/handbook_plane.json
+++ b/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/handbook_plane.json
@@ -1,23 +1,17 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        " a ",
-        "dbd",
-        " c "
+        "   ",
+        " ab",
+        "   "
     ],
     "key": {
         "a": {
-            "item": "minecraft:feather"
-        },
-        "b": {
             "item": "minecraft:book"
         },
-        "c": {
-            "type": "forge:ore_dict",
-            "ore": "dyeBlack"
-        },
-        "d": {
-            "item": "minecraft:paper"
+        "b": {
+			"item": "mts:mts.ticket",
+            "data": 0
         }
     },
     "result": {

--- a/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/instrumentbench.json
+++ b/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/instrumentbench.json
@@ -1,24 +1,28 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
-        "cdc",
-        "c c"
+        "abc",
+        "ddd",
+        "e e"
     ],
     "key": {
-        "a": {
+    	"a": {
+            "item": "minecraft:redstone_lamp"
+        },
+        "b": {
             "type": "forge:ore_dict",
             "ore": "ingotIron"
         },
-        "b": {
-            "item": "minecraft:glowstone"
-        },
         "c": {
+            "item": "minecraft:clock"
+        },
+        "d": {
             "type": "forge:ore_dict",
             "ore": "plankWood"
         },
-        "d": {
-            "item": "minecraft:redstone_block"
+        "e": {
+            "type": "forge:ore_dict",
+            "ore": "fenceWood"
         }
     },
     "result": {

--- a/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/jerrycan.json
+++ b/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/jerrycan.json
@@ -1,7 +1,7 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
+        " aa",
         "aba",
         "aaa"
     ],
@@ -11,8 +11,7 @@
             "ore": "ingotIron"
         },
         "b": {
-            "type": "forge:ore_dict",
-            "ore": "dyeRed"
+            "item": "minecraft:bucket"
         }
     },
     "result": {

--- a/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/key.json
+++ b/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/key.json
@@ -7,11 +7,10 @@
     ],
     "key": {
         "a": {
-            "type": "forge:ore_dict",
-            "ore": "ingotIron"
+            "item": "minecraft:iron_nugget"
         },
         "b": {
-            "item": "minecraft:string"
+            "item": "minecraft:clay_ball"
         }
     },
     "result": {

--- a/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/seatbench.json
+++ b/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/seatbench.json
@@ -2,7 +2,7 @@
     "type": "minecraft:crafting_shaped",
     "pattern": [
         "   ",
-        "aba",
+        "cbc",
         "a a"
     ],
     "key": {
@@ -12,6 +12,9 @@
         },
         "b": {
             "item": "minecraft:iron_axe"
+        },
+        "c": {
+            "item": "minecraft:heavy_weighted_pressure_plate"
         }
     },
     "result": {

--- a/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/ticket.json
+++ b/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/ticket.json
@@ -1,9 +1,8 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
-        "aba",
-        "ccc"
+        "ca",
+        "ab"
     ],
     "key": {
         "a": {

--- a/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/vehiclebench.json
+++ b/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/vehiclebench.json
@@ -2,8 +2,8 @@
     "type": "minecraft:crafting_shaped",
     "pattern": [
         "aaa",
-        "aba",
-        "c c"
+        "abc",
+        "d d"
     ],
     "key": {
         "a": {
@@ -11,11 +11,14 @@
             "ore": "plankWood"
         },
         "b": {
-            "type": "forge:ore_dict",
-            "ore": "fenceWood"
+            "item": "minecraft:paper"
         },
         "c": {
-            "item": "minecraft:glass_pane"
+            "item": "minecraft:writable_book"
+        },
+        "d": {
+            "type": "forge:ore_dict",
+            "ore": "fenceWood"
         }
     },
     "result": {

--- a/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/wheelbench.json
+++ b/mcinterfaceforge1122/src/main/resources/assets/mts/recipes/wheelbench.json
@@ -1,7 +1,7 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "a  ",
+        "   ",
         "abb",
         "cbb"
     ],
@@ -15,8 +15,7 @@
             "ore": "plankWood"
         },
         "c": {
-            "item": "minecraft:anvil",
-            "data": 0
+            "item": "minecraft:bucket"
         }
     },
     "result": {

--- a/mcinterfaceforge1165/src/main/resources/data/mts/recipes/enginebench.json
+++ b/mcinterfaceforge1165/src/main/resources/data/mts/recipes/enginebench.json
@@ -2,21 +2,21 @@
     "type": "minecraft:crafting_shaped",
     "pattern": [
         "aaa",
-        "bca",
-        " dd"
+        "b a",
+        "cdd"
     ],
     "key": {
         "a": {
             "tag": "forge:ingots/iron"
         },
         "b": {
-            "item": "minecraft:iron_bars"
+            "item": "minecraft:chain"
         },
         "c": {
-            "item": "minecraft:red_dye"
+            "item": "mts:mts.wrench"
         },
         "d": {
-            "item": "minecraft:iron_block"
+            "item": "minecraft:heavy_weighted_pressure_plate"
         }
     },
     "result": {

--- a/mcinterfaceforge1165/src/main/resources/data/mts/recipes/fuelpump.json
+++ b/mcinterfaceforge1165/src/main/resources/data/mts/recipes/fuelpump.json
@@ -1,25 +1,25 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
-        "cdc",
-        "eee"
+        " a ",
+        "bcd",
+        "ece"
     ],
     "key": {
         "a": {
-            "item": "minecraft:red_dye"
-        },
-        "b": {
             "item": "minecraft:glass_pane"
         },
+        "b": {
+            "item": "minecraft:red_dye"
+        },
         "c": {
-            "item": "minecraft:black_dye"
+            "item": "minecraft:bucket"
         },
         "d": {
-            "tag": "forge:ingots/iron"
+            "item": "mts:mts.fuelhose"
         },
         "e": {
-            "item": "minecraft:stone_slab"
+            "tag": "forge:ingots/iron"
         }
     },
     "result": {

--- a/mcinterfaceforge1165/src/main/resources/data/mts/recipes/gunbench.json
+++ b/mcinterfaceforge1165/src/main/resources/data/mts/recipes/gunbench.json
@@ -3,20 +3,20 @@
     "pattern": [
         "   ",
         "abc",
-        "dad"
+        "ddd"
     ],
     "key": {
         "a": {
-            "item": "minecraft:iron_block"
+            "tag": "forge:storage_blocks/iron"
         },
         "b": {
             "item": "minecraft:diamond"
         },
         "c": {
-            "item": "minecraft:red_dye"
+            "tag": "forge:ingots/iron"
         },
         "d": {
-            "item": "minecraft:green_dye"
+            "item": "minecraft:smooth_stone"
         }
     },
     "result": {

--- a/mcinterfaceforge1165/src/main/resources/data/mts/recipes/handbook_car.json
+++ b/mcinterfaceforge1165/src/main/resources/data/mts/recipes/handbook_car.json
@@ -1,22 +1,16 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        " a ",
-        "cbc",
-        " d "
+        "   ",
+        " ab",
+        "   "
     ],
     "key": {
         "a": {
-            "item": "minecraft:feather"
-        },
-        "b": {
             "item": "minecraft:book"
         },
-        "c": {
-						"item": "minecraft:black_dye"
-        },
-        "d": {
-            "item": "minecraft:paper"
+        "b": {
+			"item": "mts:mts.key"
         }
     },
     "result": {

--- a/mcinterfaceforge1165/src/main/resources/data/mts/recipes/handbook_plane.json
+++ b/mcinterfaceforge1165/src/main/resources/data/mts/recipes/handbook_plane.json
@@ -1,22 +1,16 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        " a ",
-        "dbd",
-        " c "
+        "   ",
+        " ab",
+        "   "
     ],
     "key": {
         "a": {
-            "item": "minecraft:feather"
-        },
-        "b": {
             "item": "minecraft:book"
         },
-        "c": {
-            "item": "minecraft:black_dye"
-        },
-        "d": {
-            "item": "minecraft:paper"
+        "b": {
+			"item": "mts:mts.ticket"
         }
     },
     "result": {

--- a/mcinterfaceforge1165/src/main/resources/data/mts/recipes/instrumentbench.json
+++ b/mcinterfaceforge1165/src/main/resources/data/mts/recipes/instrumentbench.json
@@ -1,22 +1,25 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
-        "cdc",
-        "c c"
+        "abc",
+        "ddd",
+        "e e"
     ],
     "key": {
         "a": {
-            "tag": "forge:ingots/iron"
+            "item": "minecraft:lantern"
         },
         "b": {
-            "item": "minecraft:glowstone"
+            "tag": "forge:ingots/iron"
         },
         "c": {
-            "tag": "minecraft:planks"
+            "item": "minecraft:clock"
         },
         "d": {
-            "item": "minecraft:redstone_block"
+            "tag": "minecraft:planks"
+        },
+        "e": {
+            "tag": "forge:fences/wooden"
         }
     },
     "result": {

--- a/mcinterfaceforge1165/src/main/resources/data/mts/recipes/jerrycan.json
+++ b/mcinterfaceforge1165/src/main/resources/data/mts/recipes/jerrycan.json
@@ -1,7 +1,7 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
+        " aa",
         "aba",
         "aaa"
     ],
@@ -10,7 +10,7 @@
             "tag": "forge:ingots/iron"
         },
         "b": {
-            "item": "minecraft:red_dye"
+            "item": "minecraft:bucket"
         }
     },
     "result": {

--- a/mcinterfaceforge1165/src/main/resources/data/mts/recipes/key.json
+++ b/mcinterfaceforge1165/src/main/resources/data/mts/recipes/key.json
@@ -7,10 +7,10 @@
     ],
     "key": {
         "a": {
-            "tag": "forge:ingots/iron"
+            "tag": "forge:nuggets/iron"
         },
         "b": {
-            "item": "minecraft:string"
+            "tag": "forge:clay"
         }
     },
     "result": {

--- a/mcinterfaceforge1165/src/main/resources/data/mts/recipes/seatbench.json
+++ b/mcinterfaceforge1165/src/main/resources/data/mts/recipes/seatbench.json
@@ -2,15 +2,18 @@
     "type": "minecraft:crafting_shaped",
     "pattern": [
         "   ",
-        "aba",
-        "a a"
+        "abb",
+        "c c"
     ],
     "key": {
         "a": {
-            "tag": "forge:ingots/iron"
+            "item": "minecraft:stonecutter"
         },
         "b": {
-            "item": "minecraft:iron_axe"
+            "item": "minecraft:heavy_weighted_pressure_plate"
+        },
+        "c": {
+            "tag": "forge:ingots/iron"
         }
     },
     "result": {

--- a/mcinterfaceforge1165/src/main/resources/data/mts/recipes/ticket.json
+++ b/mcinterfaceforge1165/src/main/resources/data/mts/recipes/ticket.json
@@ -1,9 +1,8 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
-        "aba",
-        "ccc"
+        "ca",
+        "ab"
     ],
     "key": {
         "a": {

--- a/mcinterfaceforge1165/src/main/resources/data/mts/recipes/vehiclebench.json
+++ b/mcinterfaceforge1165/src/main/resources/data/mts/recipes/vehiclebench.json
@@ -2,18 +2,24 @@
     "type": "minecraft:crafting_shaped",
     "pattern": [
         "aaa",
-        "aba",
-        "c c"
+        "bcd",
+        "e e"
     ],
     "key": {
         "a": {
             "tag": "minecraft:planks"
         },
         "b": {
-            "tag": "minecraft:wooden_fences"
+            "item": "minecraft:paper"
         },
         "c": {
-            "item": "minecraft:glass_pane"
+            "item": "minecraft:lectern"
+        },
+        "d": {
+            "item": "minecraft:writable_book"
+        },
+        "e": {
+            "tag": "forge:fences/wooden"
         }
     },
     "result": {

--- a/mcinterfaceforge1165/src/main/resources/data/mts/recipes/wheelbench.json
+++ b/mcinterfaceforge1165/src/main/resources/data/mts/recipes/wheelbench.json
@@ -1,9 +1,9 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "a  ",
+        "   ",
         "abb",
-        "cbb"
+        "dcc"
     ],
     "key": {
         "a": {
@@ -13,7 +13,10 @@
             "tag": "minecraft:planks"
         },
         "c": {
-            "item": "minecraft:anvil"
+            "tag": "minecraft:wooden_fences"
+        },
+        "d": {
+            "item": "minecraft:grindstone"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/charger.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/charger.json
@@ -3,7 +3,7 @@
     "pattern": [
         "ada",
         "bcb",
-        "aba"
+        "aea"
     ],
     "key": {
         "a": {
@@ -17,6 +17,9 @@
         },
         "d": {
             "item": "mts:mts.jumpercable"
+        },
+        "e": {
+            "tag": "forge:storage_blocks/copper"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/custombench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/custombench.json
@@ -7,7 +7,7 @@
     ],
     "key": {
         "a": {
-            "tag": "forge:ingots/iron"
+            "tag": "forge:ingots/copper"
         },
         "b": {
             "item": "minecraft:crafting_table"

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/decorbench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/decorbench.json
@@ -2,7 +2,7 @@
     "type": "minecraft:crafting_shaped",
     "pattern": [
         "a  ",
-        "bbb",
+        "ebb",
         "c d"
     ],
     "key": {
@@ -17,6 +17,9 @@
         },
         "d": {
             "tag": "forge:ingots/iron"
+        },
+        "e": {
+            "tag": "forge:ingots/copper"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/enginebench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/enginebench.json
@@ -2,21 +2,21 @@
     "type": "minecraft:crafting_shaped",
     "pattern": [
         "aaa",
-        "bca",
-        " dd"
+        "b a",
+        "cdd"
     ],
     "key": {
         "a": {
             "tag": "forge:ingots/iron"
         },
         "b": {
-            "item": "minecraft:iron_bars"
+            "item": "minecraft:chain"
         },
         "c": {
-            "item": "minecraft:red_dye"
+            "item": "mts:mts.wrench"
         },
         "d": {
-            "item": "minecraft:iron_block"
+            "item": "minecraft:heavy_weighted_pressure_plate"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/fuelpump.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/fuelpump.json
@@ -1,25 +1,25 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
-        "cdc",
-        "eee"
+        " a ",
+        "bcd",
+        "ece"
     ],
     "key": {
         "a": {
-            "item": "minecraft:red_dye"
-        },
-        "b": {
             "item": "minecraft:glass_pane"
         },
+        "b": {
+            "item": "minecraft:red_dye"
+        },
         "c": {
-            "item": "minecraft:black_dye"
+            "item": "minecraft:bucket"
         },
         "d": {
-            "tag": "forge:ingots/iron"
+            "item": "mts:mts.fuelhose"
         },
         "e": {
-            "item": "minecraft:stone_slab"
+            "tag": "forge:ingots/iron"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/gunbench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/gunbench.json
@@ -3,20 +3,20 @@
     "pattern": [
         "   ",
         "abc",
-        "dad"
+        "ddd"
     ],
     "key": {
         "a": {
-            "item": "minecraft:iron_block"
+            "tag": "forge:storage_blocks/iron"
         },
         "b": {
             "item": "minecraft:diamond"
         },
         "c": {
-            "item": "minecraft:red_dye"
+            "tag": "forge:ingots/iron"
         },
         "d": {
-            "item": "minecraft:green_dye"
+            "item": "minecraft:smooth_stone"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/handbook_car.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/handbook_car.json
@@ -1,22 +1,16 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        " a ",
-        "cbc",
-        " d "
+        "   ",
+        " ab",
+        "   "
     ],
     "key": {
         "a": {
-            "item": "minecraft:feather"
-        },
-        "b": {
             "item": "minecraft:book"
         },
-        "c": {
-						"item": "minecraft:black_dye"
-        },
-        "d": {
-            "item": "minecraft:paper"
+        "b": {
+			"item": "mts:mts.key"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/handbook_plane.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/handbook_plane.json
@@ -1,22 +1,16 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        " a ",
-        "dbd",
-        " c "
+        "   ",
+        " ab",
+        "   "
     ],
     "key": {
         "a": {
-            "item": "minecraft:feather"
-        },
-        "b": {
             "item": "minecraft:book"
         },
-        "c": {
-            "item": "minecraft:black_dye"
-        },
-        "d": {
-            "item": "minecraft:paper"
+        "b": {
+			"item": "mts:mts.ticket"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/instrumentbench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/instrumentbench.json
@@ -1,22 +1,25 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
-        "cdc",
-        "c c"
+        "abc",
+        "ddd",
+        "e e"
     ],
     "key": {
         "a": {
-            "tag": "forge:ingots/iron"
+            "item": "minecraft:lantern"
         },
         "b": {
-            "item": "minecraft:glowstone"
+            "tag": "forge:ingots/iron"
         },
         "c": {
-            "tag": "minecraft:planks"
+            "item": "minecraft:clock"
         },
         "d": {
-            "item": "minecraft:redstone_block"
+            "tag": "minecraft:planks"
+        },
+        "e": {
+            "tag": "forge:fences/wooden"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/itembench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/itembench.json
@@ -13,10 +13,10 @@
             "item": "minecraft:glass_pane"
         },
         "c": {
-            "item": "minecraft:comparator"
+            "tag": "forge:ingots/copper"
         },
         "d": {
-            "item": "minecraft:quartz"
+            "item": "minecraft:comparator"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/jerrycan.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/jerrycan.json
@@ -1,7 +1,7 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
+        " aa",
         "aba",
         "aaa"
     ],
@@ -10,7 +10,7 @@
             "tag": "forge:ingots/iron"
         },
         "b": {
-            "item": "minecraft:red_dye"
+            "item": "minecraft:bucket"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/jumpercable.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/jumpercable.json
@@ -3,7 +3,7 @@
     "pattern": [
         "a a",
         "bcb",
-        "bbb"
+        "dbd"
     ],
     "key": {
         "a": {
@@ -14,6 +14,9 @@
         },
         "c": {
             "item": "minecraft:redstone"
+        },
+        "d": {
+            "tag": "forge:ingots/copper"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/jumperpack.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/jumperpack.json
@@ -2,7 +2,7 @@
     "type": "minecraft:crafting_shaped",
     "pattern": [
         "aaa",
-        "bca",
+        "bea",
         "dcd"
     ],
     "key": {
@@ -17,6 +17,9 @@
         },
         "d": {
             "item": "minecraft:redstone"
+        },
+        "e": {
+            "tag": "forge:storage_blocks/copper"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/key.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/key.json
@@ -7,10 +7,10 @@
     ],
     "key": {
         "a": {
-            "tag": "forge:ingots/iron"
+            "tag": "forge:nuggets/iron"
         },
         "b": {
-            "item": "minecraft:string"
+            "item": "minecraft:clay_ball"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/partscanner.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/partscanner.json
@@ -1,9 +1,9 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
+        "abg",
         "cde",
-        "afa"
+        "gfa"
     ],
     "key": {
         "a": {
@@ -23,6 +23,9 @@
         },
         "f": {
             "item": "minecraft:stone_button"
+        },
+        "g": {
+            "tag": "forge:ingots/copper"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/propellerbench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/propellerbench.json
@@ -3,7 +3,7 @@
     "pattern": [
         "aaa",
         " ba",
-        "aca"
+        "acd"
     ],
     "key": {
         "a": {
@@ -14,6 +14,9 @@
         },
         "c": {
             "item": "minecraft:anvil"
+        },
+        "d": {
+            "tag": "forge:storage_blocks/copper"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/seatbench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/seatbench.json
@@ -2,15 +2,18 @@
     "type": "minecraft:crafting_shaped",
     "pattern": [
         "   ",
-        "aba",
-        "a a"
+        "abb",
+        "c c"
     ],
     "key": {
         "a": {
-            "tag": "forge:ingots/iron"
+            "item": "minecraft:stonecutter"
         },
         "b": {
-            "item": "minecraft:iron_axe"
+            "item": "minecraft:heavy_weighted_pressure_plate"
+        },
+        "c": {
+            "tag": "forge:ingots/iron"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/ticket.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/ticket.json
@@ -1,9 +1,8 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
-        "aba",
-        "ccc"
+        "ca",
+        "ab"
     ],
     "key": {
         "a": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/vehiclebench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/vehiclebench.json
@@ -2,18 +2,24 @@
     "type": "minecraft:crafting_shaped",
     "pattern": [
         "aaa",
-        "aba",
-        "c c"
+        "bcd",
+        "e e"
     ],
     "key": {
         "a": {
             "tag": "minecraft:planks"
         },
         "b": {
-            "tag": "minecraft:wooden_fences"
+            "item": "minecraft:paper"
         },
         "c": {
-            "item": "minecraft:glass_pane"
+            "item": "minecraft:lectern"
+        },
+        "d": {
+            "item": "minecraft:writable_book"
+        },
+        "e": {
+            "tag": "forge:fences/wooden"
         }
     },
     "result": {

--- a/mcinterfaceforge1182/src/main/resources/data/mts/recipes/wheelbench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/recipes/wheelbench.json
@@ -1,9 +1,9 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "a  ",
+        "   ",
         "abb",
-        "cbb"
+        "dcc"
     ],
     "key": {
         "a": {
@@ -13,7 +13,10 @@
             "tag": "minecraft:planks"
         },
         "c": {
-            "item": "minecraft:anvil"
+            "tag": "minecraft:wooden_fences"
+        },
+        "d": {
+            "item": "minecraft:grindstone"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/charger.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/charger.json
@@ -3,7 +3,7 @@
     "pattern": [
         "ada",
         "bcb",
-        "aba"
+        "aea"
     ],
     "key": {
         "a": {
@@ -17,6 +17,9 @@
         },
         "d": {
             "item": "mts:mts.jumpercable"
+        },
+        "e": {
+            "tag": "forge:storage_blocks/copper"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/custombench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/custombench.json
@@ -7,7 +7,7 @@
     ],
     "key": {
         "a": {
-            "tag": "forge:ingots/iron"
+            "tag": "forge:ingots/copper"
         },
         "b": {
             "item": "minecraft:crafting_table"

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/decorbench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/decorbench.json
@@ -2,7 +2,7 @@
     "type": "minecraft:crafting_shaped",
     "pattern": [
         "a  ",
-        "bbb",
+        "ebb",
         "c d"
     ],
     "key": {
@@ -17,6 +17,9 @@
         },
         "d": {
             "tag": "forge:ingots/iron"
+        },
+        "e": {
+            "tag": "forge:ingots/copper"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/enginebench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/enginebench.json
@@ -2,21 +2,21 @@
     "type": "minecraft:crafting_shaped",
     "pattern": [
         "aaa",
-        "bca",
-        " dd"
+        "b a",
+        "cdd"
     ],
     "key": {
         "a": {
             "tag": "forge:ingots/iron"
         },
         "b": {
-            "item": "minecraft:iron_bars"
+            "item": "minecraft:chain"
         },
         "c": {
-            "item": "minecraft:red_dye"
+            "item": "mts:mts.wrench"
         },
         "d": {
-            "item": "minecraft:iron_block"
+            "item": "minecraft:heavy_weighted_pressure_plate"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/fuelpump.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/fuelpump.json
@@ -1,25 +1,25 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
-        "cdc",
-        "eee"
+        " a ",
+        "bcd",
+        "ece"
     ],
     "key": {
         "a": {
-            "item": "minecraft:red_dye"
-        },
-        "b": {
             "item": "minecraft:glass_pane"
         },
+        "b": {
+            "item": "minecraft:red_dye"
+        },
         "c": {
-            "item": "minecraft:black_dye"
+            "item": "minecraft:bucket"
         },
         "d": {
-            "tag": "forge:ingots/iron"
+            "item": "mts:mts.fuelhose"
         },
         "e": {
-            "item": "minecraft:stone_slab"
+            "tag": "forge:ingots/iron"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/gunbench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/gunbench.json
@@ -3,20 +3,20 @@
     "pattern": [
         "   ",
         "abc",
-        "dad"
+        "ddd"
     ],
     "key": {
         "a": {
-            "item": "minecraft:iron_block"
+            "tag": "forge:storage_blocks/iron"
         },
         "b": {
             "item": "minecraft:diamond"
         },
         "c": {
-            "item": "minecraft:red_dye"
+            "tag": "forge:ingots/iron"
         },
         "d": {
-            "item": "minecraft:green_dye"
+            "item": "minecraft:smooth_stone"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/handbook_car.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/handbook_car.json
@@ -1,22 +1,16 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        " a ",
-        "cbc",
-        " d "
+        "   ",
+        " ab",
+        "   "
     ],
     "key": {
         "a": {
-            "item": "minecraft:feather"
-        },
-        "b": {
             "item": "minecraft:book"
         },
-        "c": {
-						"item": "minecraft:black_dye"
-        },
-        "d": {
-            "item": "minecraft:paper"
+        "b": {
+			"item": "mts:mts.key"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/handbook_plane.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/handbook_plane.json
@@ -1,22 +1,16 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        " a ",
-        "dbd",
-        " c "
+        "   ",
+        " ab",
+        "   "
     ],
     "key": {
         "a": {
-            "item": "minecraft:feather"
-        },
-        "b": {
             "item": "minecraft:book"
         },
-        "c": {
-            "item": "minecraft:black_dye"
-        },
-        "d": {
-            "item": "minecraft:paper"
+        "b": {
+			"item": "mts:mts.ticket"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/instrumentbench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/instrumentbench.json
@@ -1,22 +1,25 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
-        "cdc",
-        "c c"
+        "abc",
+        "ddd",
+        "e e"
     ],
     "key": {
         "a": {
-            "tag": "forge:ingots/iron"
+            "item": "minecraft:lantern"
         },
         "b": {
-            "item": "minecraft:glowstone"
+            "tag": "forge:ingots/iron"
         },
         "c": {
-            "tag": "minecraft:planks"
+            "item": "minecraft:clock"
         },
         "d": {
-            "item": "minecraft:redstone_block"
+            "tag": "minecraft:planks"
+        },
+        "e": {
+            "tag": "forge:fences/wooden"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/itembench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/itembench.json
@@ -13,10 +13,10 @@
             "item": "minecraft:glass_pane"
         },
         "c": {
-            "item": "minecraft:comparator"
+            "tag": "forge:ingots/copper"
         },
         "d": {
-            "item": "minecraft:quartz"
+            "item": "minecraft:comparator"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/jerrycan.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/jerrycan.json
@@ -1,7 +1,7 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
+        " aa",
         "aba",
         "aaa"
     ],
@@ -10,7 +10,7 @@
             "tag": "forge:ingots/iron"
         },
         "b": {
-            "item": "minecraft:red_dye"
+            "item": "minecraft:bucket"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/jumpercable.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/jumpercable.json
@@ -3,7 +3,7 @@
     "pattern": [
         "a a",
         "bcb",
-        "bbb"
+        "dbd"
     ],
     "key": {
         "a": {
@@ -14,6 +14,9 @@
         },
         "c": {
             "item": "minecraft:redstone"
+        },
+        "d": {
+            "tag": "forge:ingots/copper"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/jumperpack.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/jumperpack.json
@@ -2,7 +2,7 @@
     "type": "minecraft:crafting_shaped",
     "pattern": [
         "aaa",
-        "bca",
+        "bea",
         "dcd"
     ],
     "key": {
@@ -17,6 +17,9 @@
         },
         "d": {
             "item": "minecraft:redstone"
+        },
+        "e": {
+            "tag": "forge:storage_blocks/copper"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/key.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/key.json
@@ -7,10 +7,10 @@
     ],
     "key": {
         "a": {
-            "tag": "forge:ingots/iron"
+            "tag": "forge:nuggets/iron"
         },
         "b": {
-            "item": "minecraft:string"
+            "item": "minecraft:clay_ball"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/partscanner.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/partscanner.json
@@ -1,9 +1,9 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
+        "abg",
         "cde",
-        "afa"
+        "gfa"
     ],
     "key": {
         "a": {
@@ -23,6 +23,9 @@
         },
         "f": {
             "item": "minecraft:stone_button"
+        },
+        "g": {
+            "tag": "forge:ingots/copper"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/propellerbench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/propellerbench.json
@@ -3,7 +3,7 @@
     "pattern": [
         "aaa",
         " ba",
-        "aca"
+        "acd"
     ],
     "key": {
         "a": {
@@ -14,6 +14,9 @@
         },
         "c": {
             "item": "minecraft:anvil"
+        },
+        "d": {
+            "tag": "forge:storage_blocks/copper"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/seatbench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/seatbench.json
@@ -2,15 +2,18 @@
     "type": "minecraft:crafting_shaped",
     "pattern": [
         "   ",
-        "aba",
-        "a a"
+        "abb",
+        "c c"
     ],
     "key": {
         "a": {
-            "tag": "forge:ingots/iron"
+            "item": "minecraft:stonecutter"
         },
         "b": {
-            "item": "minecraft:iron_axe"
+            "item": "minecraft:heavy_weighted_pressure_plate"
+        },
+        "c": {
+            "tag": "forge:ingots/iron"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/ticket.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/ticket.json
@@ -1,9 +1,8 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "aba",
-        "aba",
-        "ccc"
+        "ca",
+        "ab"
     ],
     "key": {
         "a": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/vehiclebench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/vehiclebench.json
@@ -2,18 +2,24 @@
     "type": "minecraft:crafting_shaped",
     "pattern": [
         "aaa",
-        "aba",
-        "c c"
+        "bcd",
+        "e e"
     ],
     "key": {
         "a": {
             "tag": "minecraft:planks"
         },
         "b": {
-            "tag": "minecraft:wooden_fences"
+            "item": "minecraft:paper"
         },
         "c": {
-            "item": "minecraft:glass_pane"
+            "item": "minecraft:lectern"
+        },
+        "d": {
+            "item": "minecraft:writable_book"
+        },
+        "e": {
+            "tag": "forge:fences/wooden"
         }
     },
     "result": {

--- a/mcinterfaceforge1192/src/main/resources/data/mts/recipes/wheelbench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/recipes/wheelbench.json
@@ -1,9 +1,9 @@
 {
     "type": "minecraft:crafting_shaped",
     "pattern": [
-        "a  ",
+        "   ",
         "abb",
-        "cbb"
+        "dcc"
     ],
     "key": {
         "a": {
@@ -13,7 +13,10 @@
             "tag": "minecraft:planks"
         },
         "c": {
-            "item": "minecraft:anvil"
+            "tag": "minecraft:wooden_fences"
+        },
+        "d": {
+            "item": "minecraft:grindstone"
         }
     },
     "result": {


### PR DESCRIPTION
Updated most item and bench crafting recipes to either use items from higher versions (respecting each versions existing item pool) or to be more accurate to the benches updated models.

Changes:
**1.12**
- engine bench: replaced one iron block with iron pressure plate
- fuelpump: made pump use two buckets, less dye, use the MTS hose item and iron ingots at the base instead of stone slabs
- gunbench: removed dyes, base made of ingots instead
- handbook car: changed to use book + key
- handbook plane: changed to use book + ticket
- instrumentbench: uses Redstone lamp instead of glowstone, uses clock, iron ingot, fences as base
- jerrycan: removed dye, removed top left ingot from corner, center uses bucket now
- key: removed string & ingots, now uses clay ball as base + two iron nuggets
- seatbench: replaced midrib ingots with iron pressure plates
- ticket: removed dye, made recipe 2x2
- vehicle bench: added book n quill, paper, top row wood, fences as legs
- wheelbench: replaced anvil with bucket

**1.16**
- engine bench: replaced one iron block with iron pressure plate, replaced iron bars with chains, added wrench to the recipe
- fuelpump: made pump use two buckets, less dye, use the MTS hose item and iron ingots at the base instead of stone slabs
- gunbench: removed dyes, base made of smooth stone
- handbook car: changed to use book + key
- handbook plane: changed to use book + ticket
- instrumentbench: uses lantern instead of glowstone, uses clock, iron ingot, fences as base
- jerrycan: removed dye, removed top left ingot from corner, center uses bucket now
- key: removed string & ingots, now uses clay ball as base + two iron nuggets
- seatbench: replaced midrow ingots with iron pressure plates, uses stonecutter as saw blade
- ticket: removed dye, made recipe 2x2
- vehicle bench: added book n quill, paper, lectern in center, top row wood, fences as legs
- wheelbench: replaced anvil with grindstone

**1.18 & 1.19**
- charger: added copper block to mid bottom
- custom bench: replaced all iron ingots with copper ingots
- decor bench: added one copper ingot to recipe 
- engine bench: replaced one iron block with iron pressure plate
- fuelpump: made pump use two buckets, less dye, use the MTS hose item and iron ingots at the base instead of stone slabs
- gunbench: removed dyes, base made of smooth stone instead
- handbook car: changed to use book + key
- handbook plane: changed to use book + ticket
- instrumentbench: uses lantern instead of glowstone, uses clock, iron ingot, fences as base
- jerrycan: removed dye, removed top left ingot from corner, center uses bucket now
- jumper cable: bottom corners replaced string with copper ingots
- jumper pack: center yellow dye replaced with copper block
- key: removed string & ingots, now uses clay ball as base + two iron nuggets
- partscanner: replaced two iron ingots with copper ingots
- propeller bench: replaced bottom right corner iron ingot with copper block
- seatbench: replaced midrow ingots with iron pressure plates, stonecutter as saw blade
- ticket: removed dye, made recipe 2x2
- vehicle bench: added book n quill, paper, lectern at center, top row wood, fences as legs
- wheelbench: replaced anvil with grindstone

