### PR TITLE
Mr.Mulles Advancement Fix

### DIFF
--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/custombench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/custombench.json
@@ -1,16 +1,46 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.custombench"},
-        "title": {"translate": "advancements.mts.custombench.title"},
-        "description": {"translate": "advancements.mts.custombench.description"}
+        "icon": {
+        	"item": "mts:mts.custombench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.custombench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.custombench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_custombench": {
+        "custombench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.custombench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.custombench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
+    },
+    "requirements": [
+        [
+            "custombench"
+        ]
+    ],
+    "rewards": {
+        "experience": 500,
+        "recipes": [
+            "mts:fuelpump",
+            "mts:jumpercable",
+            "mts:jumperpack"
+        ]
     }
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/custombench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/custombench.json
@@ -36,7 +36,6 @@
         ]
     ],
     "rewards": {
-        "experience": 500,
         "recipes": [
             "mts:fuelpump",
             "mts:jumpercable",

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/decorbench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/decorbench.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.decorbench"},
-        "title": {"translate": "advancements.mts.decorbench.title"},
-        "description": {"translate": "advancements.mts.decorbench.description"}
+        "icon": {
+        	"item": "mts:mts.decorbench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.decorbench.title"
+        },
+        "description": {
+        	"translate": "advancements.mts.decorbench.description"
+        },
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_decorbench": {
+        "decorbench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.decorbench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.decorbench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "decorbench"
+        ]
+    ],
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/enginebench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/enginebench.json
@@ -1,18 +1,40 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.enginebench"},
-        "title": {"translate": "advancements.mts.enginebench.title"},
-        "description": {"translate": "advancements.mts.enginebench.description"}
+        "icon": {
+        	"item": "mts:mts.enginebench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.enginebench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.enginebench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_enginebench": {
+        "enginebench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.enginebench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.enginebench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
     },
+    "requirements": [
+        [
+            "enginebench"
+        ]
+    ],
     "rewards": {
         "recipes": [
             "mts:fuelpump",

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/fuelhose.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/fuelhose.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:seatbench",
     "display": {
-        "icon": {"item": "mts:mts.fuelhose"},
-        "title": {"translate": "advancements.mts.fuelhose.title"},
-        "description": {"translate": "advancements.mts.fuelhose.description"}
+        "icon": {
+        	"item": "mts:mts.fuelhose"
+        	},
+        "title": {
+        	"translate": "advancements.mts.fuelhose.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.fuelhose.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_fuelhose": {
+        "fuelhose": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.fuelhose"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.fuelhose"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "fuelhose"
+        ]
+    ]
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/fuelpump.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/fuelpump.json
@@ -1,18 +1,40 @@
 {
     "parent": "mts:enginebench",
     "display": {
-        "icon": {"item": "mts:mts.fuelpump"},
-        "title": {"translate": "advancements.mts.fuelpump.title"},
-        "description": {"translate": "advancements.mts.fuelpump.description"}
+        "icon": {
+        	"item": "mts:mts.fuelpump"
+        	},
+        "title": {
+        	"translate": "advancements.mts.fuelpump.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.fuelpump.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_fuelpump": {
+        "fuelpump": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.fuelpump"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.fuelpump"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
     },
+    "requirements": [
+        [
+            "fuelpump"
+        ]
+    ],
     "rewards": {
         "recipes": ["mts:jerrycan"]
     }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/gunbench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/gunbench.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.gunbench"},
-        "title": {"translate": "advancements.mts.gunbench.title"},
-        "description": {"translate": "advancements.mts.gunbench.description"}
+        "icon": {
+        	"item": "mts:mts.gunbench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.gunbench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.gunbench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_gunbench": {
+        "gunbench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.gunbench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.gunbench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "gunbench"
+        ]
+    ]
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/instrumentbench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/instrumentbench.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.instrumentbench"},
-        "title": {"translate": "advancements.mts.instrumentbench.title"},
-        "description": {"translate": "advancements.mts.instrumentbench.description"}
+        "icon": {
+        	"item": "mts:mts.instrumentbench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.instrumentbench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.instrumentbench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_instrumentbench": {
+        "instrumentbench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.instrumentbench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.instrumentbench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "instrumentbench"
+        ]
+    ]
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/itembench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/itembench.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.itembench"},
-        "title": {"translate": "advancements.mts.itembench.title"},
-        "description": {"translate": "advancements.mts.itembench.description"}
+        "icon": {
+        	"item": "mts:mts.itembench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.itembench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.itembench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_itembench": {
+        "itembench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.itembench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.itembench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "itembench"
+        ]
+    ]
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/jerrycan.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/jerrycan.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:fuelpump",
     "display": {
-        "icon": {"item": "mts:mts.jerrycan"},
-        "title": {"translate": "advancements.mts.jerrycan.title"},
-        "description": {"translate": "advancements.mts.jerrycan.description"}
+        "icon": {
+        	"item": "mts:mts.jerrycan"
+        	},
+        "title": {
+        	"translate": "advancements.mts.jerrycan.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.jerrycan.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_jerrycan": {
+        "jerrycan": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.jerrycan"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.jerrycan"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "jerrycan"
+        ]
+    ]
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/jumpercable.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/jumpercable.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:enginebench",
     "display": {
-        "icon": {"item": "mts:mts.jumpercable"},
-        "title": {"translate": "advancements.mts.jumpercable.title"},
-        "description": {"translate": "advancements.mts.jumpercable.description"}
+        "icon": {
+        	"item": "mts:mts.jumpercable"
+        	},
+        "title": {
+        	"translate": "advancements.mts.jumpercable.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.jumpercable.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_jumpercable": {
+        "jumpercable": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.jumpercable"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.jumpercable"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "jumpercable"
+        ]
+    ]
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/jumperpack.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/jumperpack.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:enginebench",
     "display": {
-        "icon": {"item": "mts:mts.jumperpack"},
-        "title": {"translate": "advancements.mts.jumperpack.title"},
-        "description": {"translate": "advancements.mts.jumperpack.description"}
+        "icon": {
+        	"item": "mts:mts.jumperpack"
+        	},
+        "title": {
+        	"translate": "advancements.mts.jumperpack.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.jumperpack.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_batteryjumper": {
+        "batteryjumper": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.jumperpack"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.jumperpack"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "batteryjumper"
+        ]
+    ]
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/key.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/key.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:vehiclebench",
     "display": {
-        "icon": {"item": "mts:mts.key"},
-        "title": {"translate": "advancements.mts.key.title"},
-        "description": {"translate": "advancements.mts.key.description"}
+        "icon": {
+        	"item": "mts:mts.key"
+        	},
+        "title": {
+        	"translate": "advancements.mts.key.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.key.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_key": {
+        "key": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.key"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.key"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "key"
+        ]
+    ]
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/paintgun.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/paintgun.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:vehiclebench",
     "display": {
-        "icon": {"item": "mts:mts.paintgun"},
-        "title": {"translate": "advancements.mts.paintgun.title"},
-        "description": {"translate": "advancements.mts.paintgun.description"}
+        "icon": {
+        	"item": "mts:mts.paintgun"
+        	},
+        "title": {
+        	"translate": "advancements.mts.paintgun.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.paintgun.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_paintgun": {
+        "paintgun": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.paintgun"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.paintgun"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "paintgun"
+        ]
+    ]
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/partscanner.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/partscanner.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.partscanner"},
-        "title": {"translate": "advancements.mts.partscanner.title"},
-        "description": {"translate": "advancements.mts.partscanner.description"}
+        "icon": {
+        	"item": "mts:mts.partscanner"
+        	},
+        "title": {
+        	"translate": "advancements.mts.partscanner.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.partscanner.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_partscanner": {
+        "partscanner": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.partscanner"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.partscanner"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "partscanner"
+        ]
+    ]
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/propellerbench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/propellerbench.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.propellerbench"},
-        "title": {"translate": "advancements.mts.propellerbench.title"},
-        "description": {"translate": "advancements.mts.propellerbench.description"}
+        "icon": {
+        	"item": "mts:mts.propellerbench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.propellerbench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.propellerbench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_propellerbench": {
+        "propellerbench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.propellerbench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.propellerbench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "propellerbench"
+        ]
+    ]
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/root.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/root.json
@@ -1,22 +1,30 @@
 {
     "display": {
-        "icon": {"item": "mts:mts.wrench"},
-        "title": {"translate": "advancements.mts.root.title"},
-        "description": {"translate": "advancements.mts.root.description"},
+        "icon": {
+        	"item": "mts:mts.wrench"
+        },
+        
+        "title": {
+        	"translate": "advancements.mts.root.title"
+        },
+        "description": {
+        	"translate": "advancements.mts.root.description"
+        },
+        "frame": "task",
+    	"show_toast": false,
+    	"announce_to_chat": false,
+    	"hidden": false,
         "background": "minecraft:textures/gui/advancements/backgrounds/stone.png"
     },
     "criteria": {
-        "crafting_table": {
+        "crafting": {
             "trigger": "minecraft:inventory_changed",
-            "conditions": {
-                "items": [{"item": "minecraft:crafting_table"}]
-            }
+            "conditions": {}
         }
     },
-    "rewards": {
-        "recipes": [
-            "mts:handbook_car",
-            "mts:handbook_plane"
-        ]
-    }
+    "requirements": [
+    [
+      "crafting"
+    ]
+  ]
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/rtfm.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/rtfm.json
@@ -1,18 +1,40 @@
 {
     "parent": "mts:root",
     "display": {
-        "icon": {"item": "mts:mts.handbook_car"},
-        "title": {"translate": "advancements.mts.rtfm.title"},
-        "description": {"translate": "advancements.mts.rtfm.description"}
+        "icon": {
+        	"item": "mts:mts.handbook_car"
+        },
+        "title": {
+        	"translate": "advancements.mts.rtfm.title"
+        },
+        "description": {
+        	"translate": "advancements.mts.rtfm.description"
+        },
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_manual": {
+        "manual": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.handbook_car"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.handbook_car"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
     },
+    "requirements": [
+    [
+      "manual"
+    ]
+  ],
     "rewards": {
         "recipes": [
             "mts:partscanner",

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/seatbench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/seatbench.json
@@ -1,18 +1,40 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.seatbench"},
-        "title": {"translate": "advancements.mts.seatbench.title"},
-        "description": {"translate": "advancements.mts.seatbench.description"}
+        "icon": {
+        	"item": "mts:mts.seatbench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.seatbench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.seatbench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_seatbench": {
+        "seatbench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.seatbench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.seatbench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
     },
+    "requirements": [
+        [
+            "seatbench"
+        ]
+    ],
     "rewards": {
         "recipes": ["mts:fuelhose"]
     }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/ticket.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/ticket.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:vehiclebench",
     "display": {
-        "icon": {"item": "mts:mts.ticket"},
-        "title": {"translate": "advancements.mts.ticket.title"},
-        "description": {"translate": "advancements.mts.ticket.description"}
+        "icon": {
+        	"item": "mts:mts.ticket"
+        	},
+        "title": {
+        	"translate": "advancements.mts.ticket.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.ticket.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_ticket": {
+        "ticket": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.ticket"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.ticket"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "ticket"
+        ]
+    ]
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/vehiclebench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/vehiclebench.json
@@ -1,16 +1,33 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.vehiclebench"},
-        "title": {"translate": "advancements.mts.vehiclebench.title"},
-        "description": {"translate": "advancements.mts.vehiclebench.description"}
+        "icon": {
+        	"item": "mts:mts.vehiclebench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.vehiclebench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.vehiclebench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_vehiclebench": {
+        "vehiclebench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.vehiclebench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.vehiclebench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
     },
     "rewards": {
@@ -20,5 +37,10 @@
             "mts:ticket",
             "mts:wrench"
         ]
-    }
+    },
+    "requirements": [
+        [
+            "vehiclebench"
+        ]
+    ]
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/wheelbench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/wheelbench.json
@@ -1,16 +1,37 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.wheelbench"},
-        "title": {"translate": "advancements.mts.wheelbench.title"},
-        "description": {"translate": "advancements.mts.wheelbench.description"}
+        "icon": {
+        	"item": "mts:mts.wheelbench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.wheelbench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.wheelbench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_wheelbench": {
+        "wheelbench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.wheelbench"}]
-            }
-        }
-    }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.wheelbench"
+            				]
+            			}
+            		]
+            	}
+        	}
+    },
+    "requirements": [
+        [
+            "wheelbench"
+        ]
+    ]
 }

--- a/mcinterfaceforge1182/src/main/resources/data/mts/advancements/wrench.json
+++ b/mcinterfaceforge1182/src/main/resources/data/mts/advancements/wrench.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:vehiclebench",
     "display": {
-        "icon": {"item": "mts:mts.wrench"},
-        "title": {"translate": "advancements.mts.wrench.title"},
-        "description": {"translate": "advancements.mts.wrench.description"}
+        "icon": {
+        	"item": "mts:mts.wrench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.wrench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.wrench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_wrench": {
+        "wrench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.wrench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.wrench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "wrench"
+        ]
+    ]
 }

--- a/mcinterfaceforge1182/src/main/resources/pack.mcmeta
+++ b/mcinterfaceforge1182/src/main/resources/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
         "description": "Immersive Vehicles Resources",
-        "pack_format": 6,
+        "pack_format": 9,
         "_comment": "A pack_format of 6 requires json lang files and some texture changes from 1.16.2. Note: we require v6 pack meta for all mods."
     }
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/custombench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/custombench.json
@@ -1,16 +1,46 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.custombench"},
-        "title": {"translate": "advancements.mts.custombench.title"},
-        "description": {"translate": "advancements.mts.custombench.description"}
+        "icon": {
+        	"item": "mts:mts.custombench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.custombench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.custombench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_custombench": {
+        "custombench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.custombench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.custombench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
+    },
+    "requirements": [
+        [
+            "custombench"
+        ]
+    ],
+    "rewards": {
+        "experience": 500,
+        "recipes": [
+            "mts:fuelpump",
+            "mts:jumpercable",
+            "mts:jumperpack"
+        ]
     }
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/decorbench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/decorbench.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.decorbench"},
-        "title": {"translate": "advancements.mts.decorbench.title"},
-        "description": {"translate": "advancements.mts.decorbench.description"}
+        "icon": {
+        	"item": "mts:mts.decorbench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.decorbench.title"
+        },
+        "description": {
+        	"translate": "advancements.mts.decorbench.description"
+        },
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_decorbench": {
+        "decorbench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.decorbench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.decorbench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "decorbench"
+        ]
+    ],
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/enginebench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/enginebench.json
@@ -1,18 +1,40 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.enginebench"},
-        "title": {"translate": "advancements.mts.enginebench.title"},
-        "description": {"translate": "advancements.mts.enginebench.description"}
+        "icon": {
+        	"item": "mts:mts.enginebench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.enginebench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.enginebench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_enginebench": {
+        "enginebench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.enginebench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.enginebench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
     },
+    "requirements": [
+        [
+            "enginebench"
+        ]
+    ],
     "rewards": {
         "recipes": [
             "mts:fuelpump",

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/fuelhose.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/fuelhose.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:seatbench",
     "display": {
-        "icon": {"item": "mts:mts.fuelhose"},
-        "title": {"translate": "advancements.mts.fuelhose.title"},
-        "description": {"translate": "advancements.mts.fuelhose.description"}
+        "icon": {
+        	"item": "mts:mts.fuelhose"
+        	},
+        "title": {
+        	"translate": "advancements.mts.fuelhose.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.fuelhose.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_fuelhose": {
+        "fuelhose": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.fuelhose"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.fuelhose"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "fuelhose"
+        ]
+    ]
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/fuelpump.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/fuelpump.json
@@ -1,18 +1,40 @@
 {
     "parent": "mts:enginebench",
     "display": {
-        "icon": {"item": "mts:mts.fuelpump"},
-        "title": {"translate": "advancements.mts.fuelpump.title"},
-        "description": {"translate": "advancements.mts.fuelpump.description"}
+        "icon": {
+        	"item": "mts:mts.fuelpump"
+        	},
+        "title": {
+        	"translate": "advancements.mts.fuelpump.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.fuelpump.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_fuelpump": {
+        "fuelpump": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.fuelpump"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.fuelpump"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
     },
+    "requirements": [
+        [
+            "fuelpump"
+        ]
+    ],
     "rewards": {
         "recipes": ["mts:jerrycan"]
     }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/gunbench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/gunbench.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.gunbench"},
-        "title": {"translate": "advancements.mts.gunbench.title"},
-        "description": {"translate": "advancements.mts.gunbench.description"}
+        "icon": {
+        	"item": "mts:mts.gunbench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.gunbench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.gunbench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_gunbench": {
+        "gunbench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.gunbench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.gunbench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "gunbench"
+        ]
+    ]
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/instrumentbench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/instrumentbench.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.instrumentbench"},
-        "title": {"translate": "advancements.mts.instrumentbench.title"},
-        "description": {"translate": "advancements.mts.instrumentbench.description"}
+        "icon": {
+        	"item": "mts:mts.instrumentbench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.instrumentbench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.instrumentbench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_instrumentbench": {
+        "instrumentbench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.instrumentbench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.instrumentbench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "instrumentbench"
+        ]
+    ]
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/itembench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/itembench.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.itembench"},
-        "title": {"translate": "advancements.mts.itembench.title"},
-        "description": {"translate": "advancements.mts.itembench.description"}
+        "icon": {
+        	"item": "mts:mts.itembench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.itembench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.itembench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_itembench": {
+        "itembench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.itembench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.itembench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "itembench"
+        ]
+    ]
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/jerrycan.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/jerrycan.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:fuelpump",
     "display": {
-        "icon": {"item": "mts:mts.jerrycan"},
-        "title": {"translate": "advancements.mts.jerrycan.title"},
-        "description": {"translate": "advancements.mts.jerrycan.description"}
+        "icon": {
+        	"item": "mts:mts.jerrycan"
+        	},
+        "title": {
+        	"translate": "advancements.mts.jerrycan.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.jerrycan.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_jerrycan": {
+        "jerrycan": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.jerrycan"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.jerrycan"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "jerrycan"
+        ]
+    ]
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/jumpercable.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/jumpercable.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:enginebench",
     "display": {
-        "icon": {"item": "mts:mts.jumpercable"},
-        "title": {"translate": "advancements.mts.jumpercable.title"},
-        "description": {"translate": "advancements.mts.jumpercable.description"}
+        "icon": {
+        	"item": "mts:mts.jumpercable"
+        	},
+        "title": {
+        	"translate": "advancements.mts.jumpercable.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.jumpercable.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_jumpercable": {
+        "jumpercable": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.jumpercable"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.jumpercable"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "jumpercable"
+        ]
+    ]
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/jumperpack.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/jumperpack.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:enginebench",
     "display": {
-        "icon": {"item": "mts:mts.jumperpack"},
-        "title": {"translate": "advancements.mts.jumperpack.title"},
-        "description": {"translate": "advancements.mts.jumperpack.description"}
+        "icon": {
+        	"item": "mts:mts.jumperpack"
+        	},
+        "title": {
+        	"translate": "advancements.mts.jumperpack.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.jumperpack.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_batteryjumper": {
+        "batteryjumper": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.jumperpack"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.jumperpack"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "batteryjumper"
+        ]
+    ]
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/key.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/key.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:vehiclebench",
     "display": {
-        "icon": {"item": "mts:mts.key"},
-        "title": {"translate": "advancements.mts.key.title"},
-        "description": {"translate": "advancements.mts.key.description"}
+        "icon": {
+        	"item": "mts:mts.key"
+        	},
+        "title": {
+        	"translate": "advancements.mts.key.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.key.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_key": {
+        "key": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.key"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.key"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "key"
+        ]
+    ]
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/paintgun.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/paintgun.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:vehiclebench",
     "display": {
-        "icon": {"item": "mts:mts.paintgun"},
-        "title": {"translate": "advancements.mts.paintgun.title"},
-        "description": {"translate": "advancements.mts.paintgun.description"}
+        "icon": {
+        	"item": "mts:mts.paintgun"
+        	},
+        "title": {
+        	"translate": "advancements.mts.paintgun.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.paintgun.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_paintgun": {
+        "paintgun": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.paintgun"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.paintgun"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "paintgun"
+        ]
+    ]
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/partscanner.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/partscanner.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.partscanner"},
-        "title": {"translate": "advancements.mts.partscanner.title"},
-        "description": {"translate": "advancements.mts.partscanner.description"}
+        "icon": {
+        	"item": "mts:mts.partscanner"
+        	},
+        "title": {
+        	"translate": "advancements.mts.partscanner.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.partscanner.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_partscanner": {
+        "partscanner": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.partscanner"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.partscanner"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "partscanner"
+        ]
+    ]
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/propellerbench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/propellerbench.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.propellerbench"},
-        "title": {"translate": "advancements.mts.propellerbench.title"},
-        "description": {"translate": "advancements.mts.propellerbench.description"}
+        "icon": {
+        	"item": "mts:mts.propellerbench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.propellerbench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.propellerbench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_propellerbench": {
+        "propellerbench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.propellerbench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.propellerbench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "propellerbench"
+        ]
+    ]
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/root.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/root.json
@@ -1,22 +1,30 @@
 {
     "display": {
-        "icon": {"item": "mts:mts.wrench"},
-        "title": {"translate": "advancements.mts.root.title"},
-        "description": {"translate": "advancements.mts.root.description"},
+        "icon": {
+        	"item": "mts:mts.wrench"
+        },
+        
+        "title": {
+        	"translate": "advancements.mts.root.title"
+        },
+        "description": {
+        	"translate": "advancements.mts.root.description"
+        },
+        "frame": "task",
+    	"show_toast": false,
+    	"announce_to_chat": false,
+    	"hidden": false,
         "background": "minecraft:textures/gui/advancements/backgrounds/stone.png"
     },
     "criteria": {
-        "crafting_table": {
+        "crafting": {
             "trigger": "minecraft:inventory_changed",
-            "conditions": {
-                "items": [{"item": "minecraft:crafting_table"}]
-            }
+            "conditions": {}
         }
     },
-    "rewards": {
-        "recipes": [
-            "mts:handbook_car",
-            "mts:handbook_plane"
-        ]
-    }
+    "requirements": [
+    [
+      "crafting"
+    ]
+  ]
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/rtfm.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/rtfm.json
@@ -1,18 +1,40 @@
 {
     "parent": "mts:root",
     "display": {
-        "icon": {"item": "mts:mts.handbook_car"},
-        "title": {"translate": "advancements.mts.rtfm.title"},
-        "description": {"translate": "advancements.mts.rtfm.description"}
+        "icon": {
+        	"item": "mts:mts.handbook_car"
+        },
+        "title": {
+        	"translate": "advancements.mts.rtfm.title"
+        },
+        "description": {
+        	"translate": "advancements.mts.rtfm.description"
+        },
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_manual": {
+        "manual": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.handbook_car"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.handbook_car"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
     },
+    "requirements": [
+    [
+      "manual"
+    ]
+  ],
     "rewards": {
         "recipes": [
             "mts:partscanner",

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/seatbench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/seatbench.json
@@ -1,18 +1,40 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.seatbench"},
-        "title": {"translate": "advancements.mts.seatbench.title"},
-        "description": {"translate": "advancements.mts.seatbench.description"}
+        "icon": {
+        	"item": "mts:mts.seatbench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.seatbench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.seatbench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_seatbench": {
+        "seatbench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.seatbench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.seatbench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
     },
+    "requirements": [
+        [
+            "seatbench"
+        ]
+    ],
     "rewards": {
         "recipes": ["mts:fuelhose"]
     }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/ticket.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/ticket.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:vehiclebench",
     "display": {
-        "icon": {"item": "mts:mts.ticket"},
-        "title": {"translate": "advancements.mts.ticket.title"},
-        "description": {"translate": "advancements.mts.ticket.description"}
+        "icon": {
+        	"item": "mts:mts.ticket"
+        	},
+        "title": {
+        	"translate": "advancements.mts.ticket.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.ticket.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_ticket": {
+        "ticket": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.ticket"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.ticket"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "ticket"
+        ]
+    ]
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/vehiclebench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/vehiclebench.json
@@ -1,16 +1,33 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.vehiclebench"},
-        "title": {"translate": "advancements.mts.vehiclebench.title"},
-        "description": {"translate": "advancements.mts.vehiclebench.description"}
+        "icon": {
+        	"item": "mts:mts.vehiclebench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.vehiclebench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.vehiclebench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_vehiclebench": {
+        "vehiclebench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.vehiclebench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.vehiclebench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
     },
     "rewards": {
@@ -20,5 +37,10 @@
             "mts:ticket",
             "mts:wrench"
         ]
-    }
+    },
+    "requirements": [
+        [
+            "vehiclebench"
+        ]
+    ]
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/wheelbench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/wheelbench.json
@@ -1,16 +1,37 @@
 {
     "parent": "mts:rtfm",
     "display": {
-        "icon": {"item": "mts:mts.wheelbench"},
-        "title": {"translate": "advancements.mts.wheelbench.title"},
-        "description": {"translate": "advancements.mts.wheelbench.description"}
+        "icon": {
+        	"item": "mts:mts.wheelbench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.wheelbench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.wheelbench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_wheelbench": {
+        "wheelbench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.wheelbench"}]
-            }
-        }
-    }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.wheelbench"
+            				]
+            			}
+            		]
+            	}
+        	}
+    },
+    "requirements": [
+        [
+            "wheelbench"
+        ]
+    ]
 }

--- a/mcinterfaceforge1192/src/main/resources/data/mts/advancements/wrench.json
+++ b/mcinterfaceforge1192/src/main/resources/data/mts/advancements/wrench.json
@@ -1,16 +1,38 @@
 {
     "parent": "mts:vehiclebench",
     "display": {
-        "icon": {"item": "mts:mts.wrench"},
-        "title": {"translate": "advancements.mts.wrench.title"},
-        "description": {"translate": "advancements.mts.wrench.description"}
+        "icon": {
+        	"item": "mts:mts.wrench"
+        	},
+        "title": {
+        	"translate": "advancements.mts.wrench.title"
+        	},
+        "description": {
+        	"translate": "advancements.mts.wrench.description"
+        	},
+        "frame": "task",
+    	"show_toast": true,
+    	"announce_to_chat": false,
+    	"hidden": false
     },
     "criteria": {
-        "has_wrench": {
+        "wrench": {
             "trigger": "minecraft:inventory_changed",
             "conditions": {
-                "items": [{"item": "mts:mts.wrench"}]
-            }
+            	"items": [
+            		{
+            			"items": [
+            				"mts:mts.wrench"
+            				]
+            			}
+            		]
+            	}
+        	}
         }
-    }
+    },
+    "requirements": [
+        [
+            "wrench"
+        ]
+    ]
 }

--- a/mcinterfaceforge1192/src/main/resources/pack.mcmeta
+++ b/mcinterfaceforge1192/src/main/resources/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
         "description": "Immersive Vehicles Resources",
-        "pack_format": 6,
-        "_comment": "A pack_format of 6 requires json lang files and some texture changes from 1.16.2. Note: we require v6 pack meta for all mods."
+        "pack_format": 10,
+        "_comment": "A pack_format of 10 required for 1.19.2. Note: we require v6 pack meta for all mods."
     }
 }


### PR DESCRIPTION
Fixed and cleaned up code, updating it to the newest and compatible format.
Issues that were causing faulty advancement behaviour:
- (suspected) False pack.mcmeta packID:, being 6 for 1.18 & 1.19 builds even though 6 is a 1.16 pack ID
- False `criteria``conditions` item formatting.
  - Before: `"conditions": {"items": [{"item": "mts:mts.custombench"}]`
  - After: `"conditions": {"items": [{"items": ["farmersdelight:ham"]}]}`
- Missing `"requirements": [...]
