### PR TITLE
Seperate elevator control from ballast

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityVehicleF_Physics.java
@@ -90,6 +90,7 @@ public class EntityVehicleF_Physics extends AEntityVehicleE_Powered {
 
     //Physics properties
     public final ComputedVariable dragCoefficientVar;
+    public final ComputedVariable ballastControlVar;
     public final ComputedVariable ballastVolumeVar;
     public final ComputedVariable waterBallastFactorVar;
     public final ComputedVariable axleRatioVar;
@@ -151,6 +152,7 @@ public class EntityVehicleF_Physics extends AEntityVehicleE_Powered {
         addVariable(this.autolevelEnabledVar = new ComputedVariable(this, "auto_level", data));
 
         addVariable(this.dragCoefficientVar = new ComputedVariable(this, "dragCoefficient"));
+        addVariable(this.ballastControlVar = new ComputedVariable(this, "ballastControl", data));
         addVariable(this.ballastVolumeVar = new ComputedVariable(this, "ballastVolume"));
         addVariable(this.waterBallastFactorVar = new ComputedVariable(this, "waterBallastFactor"));
         addVariable(this.axleRatioVar = new ComputedVariable(this, "axleRatio"));
@@ -244,6 +246,7 @@ public class EntityVehicleF_Physics extends AEntityVehicleE_Powered {
         }
 
         dragCoefficientVar.setTo(definition.motorized.dragCoefficient, false);
+        ballastControlVar.setTo(elevatorInputVar.currentValue, false);
         ballastVolumeVar.setTo(definition.motorized.ballastVolume, false);
         waterBallastFactorVar.setTo(definition.motorized.waterBallastFactor, false);
         axleRatioVar.setTo(definition.motorized.axleRatio, false);
@@ -363,10 +366,10 @@ public class EntityVehicleF_Physics extends AEntityVehicleE_Powered {
                 //Ballast gets less effective at applying positive lift at higher altitudes.
                 //This prevents blimps from ascending into space.
                 //Also take into account motionY, as we should provide less force if we are already going in the same direction.
-                if (elevatorAngleVar.currentValue < 0) {
-                    ballastForce = airDensity * ballastVolumeVar.currentValue * -elevatorAngleVar.currentValue / 10D;
-                } else if (elevatorAngleVar.currentValue > 0) {
-                    ballastForce = 1.225 * ballastVolumeVar.currentValue * -elevatorAngleVar.currentValue / 10D;
+                if (ballastControlVar.currentValue < 0) {
+                    ballastForce = airDensity * ballastVolumeVar.currentValue * -ballastControlVar.currentValue / 10D;
+                } else if (ballastControlVar.currentValue > 0) {
+                    ballastForce = 1.225 * ballastVolumeVar.currentValue * -ballastControlVar.currentValue / 10D;
                 } else if (motion.y < -0.15 || motion.y > 0.15) {
                     ballastForce = 1.225 * ballastVolumeVar.currentValue * 10D * -motion.y;
                 } else {


### PR DESCRIPTION
Still keeps compatibility with blimps by defaulting to elevatorAngle when unmodified. However, the ballast difference can now be modified and overrode by VMs if needed

Allows for vehicles that can float, but also pitch independently of each other