### PR TITLE
hotfix to stop crashes from props not derectly attached to an engine

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartPropeller.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartPropeller.java
@@ -252,7 +252,7 @@ public class PartPropeller extends APart {
             propellerForce.set(propellerAxisVector).scale(thrust);
             force.add(propellerForce);
             propellerForce.reOrigin(vehicleOn.orientation);
-            if (partOn.definition.engine.allowThrustVector) {
+            if (partOn != null && partOn.definition.engine.allowThrustVector) {
                 torque.add(localOffset.crossProduct(propellerForce));
             } else {
                 torque.y -= propellerForce.z * localOffset.x;


### PR DESCRIPTION
I made an oopsie with the last change to add the opt in thrust vectoring. there was a game breaking bug where helis would crash the game due to it. this fixes it. fairly urgent change as it fixes my game breaking mistake. thanks.