### PR TITLE
Mr.Mulles "curser over hotbox group" variable

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/guis/instances/GUIOverlay.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/guis/instances/GUIOverlay.java
@@ -9,7 +9,7 @@ import minecrafttransportsimulator.baseclasses.ColorRGB;
 import minecrafttransportsimulator.baseclasses.EntityInteractResult;
 import minecrafttransportsimulator.baseclasses.Point3D;
 import minecrafttransportsimulator.entities.components.AEntityB_Existing;
-import minecrafttransportsimulator.entities.components.AEntityE_Interactable; //cursor_hover_hitbox_group
+import minecrafttransportsimulator.entities.components.AEntityE_Interactable;
 import minecrafttransportsimulator.entities.components.AEntityF_Multipart;
 import minecrafttransportsimulator.entities.instances.EntityPlayerGun;
 import minecrafttransportsimulator.entities.instances.PartInteractable;
@@ -40,8 +40,8 @@ public class GUIOverlay extends AGUIBase {
     private GUIComponentItem scannerItem;
     private final List<String> tooltipText = new ArrayList<>();
     private EntityInteractResult lastInteractResult;
-    private AEntityE_Interactable<?> lastCollisionGroupHoverEntity; //cursor_hover_hitbox_group
-    private int lastCollisionGroupHoverIndex; //cursor_hover_hitbox_group
+    private AEntityE_Interactable<?> lastCollisionGroupHoverEntity;
+    private int lastCollisionGroupHoverIndex;
 
     @Override
     public void setupComponents() {
@@ -113,7 +113,7 @@ public class GUIOverlay extends AGUIBase {
             interactResult.entity.playerCursorHoveredVar.setActive(true, false);
             lastInteractResult = interactResult;
         }
-        //cursor_hover_hitbox_group
+        
         int hoveredCollisionGroupIndex = getCollisionGroupIndex(interactResult);
         if (lastCollisionGroupHoverEntity != null && (interactResult == null || interactResult.entity != lastCollisionGroupHoverEntity || hoveredCollisionGroupIndex != lastCollisionGroupHoverIndex)) {
             lastCollisionGroupHoverEntity.getOrCreateVariable("collision_" + lastCollisionGroupHoverIndex + "_player_cursor_hovered").setActive(false, false);
@@ -240,7 +240,7 @@ public class GUIOverlay extends AGUIBase {
         return CameraSystem.customCameraOverlay;
     }
 
-    //cursor_hover_hitbox_group
+   
     private static int getCollisionGroupIndex(EntityInteractResult interactResult) {
         if (interactResult != null && interactResult.box.groupDef != null && interactResult.entity.definition.collisionGroups != null) {
             return interactResult.entity.definition.collisionGroups.indexOf(interactResult.box.groupDef) + 1;


### PR DESCRIPTION
@DonBruce64 

Added the variable `collision_x_player_cursor_hovered`

Returns 1 when the targeted collision group has a player looking at it.


Video Demonstration of the thing in action:
https://github.com/user-attachments/assets/4fa0003d-97a3-4fd3-b375-b4c3d477546b

https://cdn.discordapp.com/attachments/289084393442639872/1474828909945028863/waddwa.mov?ex=699b44f5&is=6999f375&hm=57a26d0ea60fec5c086cad118eb08c36be4440eff52c988ad4b9de48718df193&




