### PR TITLE
Fixed Explosions + external Damage completely blending a vehicle

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONConfigSettings.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONConfigSettings.java
@@ -93,7 +93,8 @@ public class JSONConfigSettings {
         public JSONConfigEntry<Boolean> wheelBreakage = new JSONConfigEntry<>(true, "Whether or not wheels can be broken (go flat).");
         public JSONConfigEntry<Boolean> wheelDamageIgnoreVelocity = new JSONConfigEntry<>(false, "Whether or not velocity is ignored when calculating wheel damage.");
         public JSONConfigEntry<Boolean> allowExternalDamage = new JSONConfigEntry<>(true, "Whether or not non-IV things can damage vehicles.  This is normally false, as external damage is a hassle for most people, but can be true if you want other mod's guns to be able to attack vehicles in addition to IV's.");
-        public JSONConfigEntry<Double> propellerDamageFactor = new JSONConfigEntry<>(1.0D, "Factor for damage caused by a propeller.");
+         public JSONConfigEntry<Double> externalExplosionDamageFactor = new JSONConfigEntry<>(1.0D, "Factor for damage from external explosions when allowExternalDamage is enabled.");
+        public JSONConfigEntry<Double> propellerDamageFactor = new JSONConfigEntry<>(3.0D, "Factor for damage caused by a propeller.");
         public JSONConfigEntry<Double> jetDamageFactor = new JSONConfigEntry<>(1.0D, "Factor for damage caused by a jet engine.");
         public JSONConfigEntry<Double> wheelDamageFactor = new JSONConfigEntry<>(1.0D, "Factor for damage caused by wheels on vehicles.");
         public JSONConfigEntry<Double> crashDamageFactor = new JSONConfigEntry<>(1.0D, "Factor for damage caused by crashes.");

--- a/mcinterfaceforge1122/src/main/java/mcinterface1122/BuilderEntityExisting.java
+++ b/mcinterfaceforge1122/src/main/java/mcinterface1122/BuilderEntityExisting.java
@@ -174,11 +174,13 @@ public class BuilderEntityExisting extends ABuilderEntityBase {
             if (lastExplosionPosition != null && source.isExplosion()) {
                 //We encountered an explosion.  These may or may not have have entities linked to them.  Depends on if
                 //it's a player firing a gun that had a bullet, or a random TNT lighting in the world.
-                //Explosions, unlike other damage sources, can hit multiple collision boxes on an entity at once.
+                //Explosions can hit multiple boxes at once.  Apply damage once to the core entity to prevent
+                //parts from forwarding duplicate explosive damage back into the same vehicle.
                 BoundingBox explosiveBounds = new BoundingBox(lastExplosionPosition, amount, amount, amount);
                 for (BoundingBox box : interactAttackBoxes.getBoxes()) {
                     if (box.intersects(explosiveBounds)) {
-                        multipart.attack(new Damage(amount, box, null, playerSource, null).setExplosive());
+                        multipart.attack(new Damage(amount, null, null, playerSource, null).setExplosive());
+                        break;
                     }
                 }
                 lastExplosionPosition = null;

--- a/mcinterfaceforge1122/src/main/java/mcinterface1122/BuilderEntityExisting.java
+++ b/mcinterfaceforge1122/src/main/java/mcinterface1122/BuilderEntityExisting.java
@@ -179,7 +179,7 @@ public class BuilderEntityExisting extends ABuilderEntityBase {
                 BoundingBox explosiveBounds = new BoundingBox(lastExplosionPosition, amount, amount, amount);
                 for (BoundingBox box : interactAttackBoxes.getBoxes()) {
                     if (box.intersects(explosiveBounds)) {
-                        multipart.attack(new Damage(amount, null, null, playerSource, null).setExplosive());
+                        multipart.attack(new Damage(amount * ConfigSystem.settings.damage.externalExplosionDamageFactor.value, null, null, playerSource, null).setExplosive());
                         break;
                     }
                 }

--- a/mcinterfaceforge1165/src/main/java/mcinterface1165/BuilderEntityExisting.java
+++ b/mcinterfaceforge1165/src/main/java/mcinterface1165/BuilderEntityExisting.java
@@ -174,11 +174,13 @@ public class BuilderEntityExisting extends ABuilderEntityBase {
             if (lastExplosionPosition != null && source.isExplosion()) {
                 //We encountered an explosion.  These may or may not have have entities linked to them.  Depends on if
                 //it's a player firing a gun that had a bullet, or a random TNT lighting in the world.
-                //Explosions, unlike other damage sources, can hit multiple collision boxes on an entity at once.
+                //Explosions can hit multiple boxes at once.  Apply damage once to the core entity to prevent
+                //parts from forwarding duplicate explosive damage back into the same vehicle.
                 BoundingBox explosiveBounds = new BoundingBox(lastExplosionPosition, amount, amount, amount);
                 for (BoundingBox box : interactAttackBoxes.getBoxes()) {
                     if (box.intersects(explosiveBounds)) {
-                        multipart.attack(new Damage(amount, box, null, playerSource, null).setExplosive());
+                        multipart.attack(new Damage(amount, null, null, playerSource, null).setExplosive());
+                        break;
                     }
                 }
                 lastExplosionPosition = null;

--- a/mcinterfaceforge1165/src/main/java/mcinterface1165/BuilderEntityExisting.java
+++ b/mcinterfaceforge1165/src/main/java/mcinterface1165/BuilderEntityExisting.java
@@ -179,7 +179,7 @@ public class BuilderEntityExisting extends ABuilderEntityBase {
                 BoundingBox explosiveBounds = new BoundingBox(lastExplosionPosition, amount, amount, amount);
                 for (BoundingBox box : interactAttackBoxes.getBoxes()) {
                     if (box.intersects(explosiveBounds)) {
-                        multipart.attack(new Damage(amount, null, null, playerSource, null).setExplosive());
+                        multipart.attack(new Damage(amount * ConfigSystem.settings.damage.externalExplosionDamageFactor.value, null, null, playerSource, null).setExplosive());
                         break;
                     }
                 }

--- a/mcinterfaceforge1182/src/main/java/mcinterface1182/BuilderEntityExisting.java
+++ b/mcinterfaceforge1182/src/main/java/mcinterface1182/BuilderEntityExisting.java
@@ -182,7 +182,7 @@ public class BuilderEntityExisting extends ABuilderEntityBase {
                 BoundingBox explosiveBounds = new BoundingBox(lastExplosionPosition, amount, amount, amount);
                 for (BoundingBox box : interactAttackBoxes.getBoxes()) {
                     if (box.intersects(explosiveBounds)) {
-                        multipart.attack(new Damage(amount, null, null, playerSource, null).setExplosive());
+                        multipart.attack(new Damage(amount * ConfigSystem.settings.damage.externalExplosionDamageFactor.value, null, null, playerSource, null).setExplosive());
                         break;
                     }
                 }

--- a/mcinterfaceforge1182/src/main/java/mcinterface1182/BuilderEntityExisting.java
+++ b/mcinterfaceforge1182/src/main/java/mcinterface1182/BuilderEntityExisting.java
@@ -177,11 +177,13 @@ public class BuilderEntityExisting extends ABuilderEntityBase {
             if (lastExplosionPosition != null && source.isExplosion()) {
                 //We encountered an explosion.  These may or may not have have entities linked to them.  Depends on if
                 //it's a player firing a gun that had a bullet, or a random TNT lighting in the world.
-                //Explosions, unlike other damage sources, can hit multiple collision boxes on an entity at once.
+                //Explosions can hit multiple boxes at once.  Apply damage once to the core entity to prevent
+                //parts from forwarding duplicate explosive damage back into the same vehicle.
                 BoundingBox explosiveBounds = new BoundingBox(lastExplosionPosition, amount, amount, amount);
                 for (BoundingBox box : interactAttackBoxes.getBoxes()) {
                     if (box.intersects(explosiveBounds)) {
-                        multipart.attack(new Damage(amount, box, null, playerSource, null).setExplosive());
+                        multipart.attack(new Damage(amount, null, null, playerSource, null).setExplosive());
+                        break;
                     }
                 }
                 lastExplosionPosition = null;

--- a/mcinterfaceforge1192/src/main/java/mcinterface1192/BuilderEntityExisting.java
+++ b/mcinterfaceforge1192/src/main/java/mcinterface1192/BuilderEntityExisting.java
@@ -182,7 +182,7 @@ public class BuilderEntityExisting extends ABuilderEntityBase {
                 BoundingBox explosiveBounds = new BoundingBox(lastExplosionPosition, amount, amount, amount);
                 for (BoundingBox box : interactAttackBoxes.getBoxes()) {
                     if (box.intersects(explosiveBounds)) {
-                        multipart.attack(new Damage(amount, null, null, playerSource, null).setExplosive());
+                        multipart.attack(new Damage(amount * ConfigSystem.settings.damage.externalExplosionDamageFactor.value, null, null, playerSource, null).setExplosive());
                         break;
                     }
                 }

--- a/mcinterfaceforge1192/src/main/java/mcinterface1192/BuilderEntityExisting.java
+++ b/mcinterfaceforge1192/src/main/java/mcinterface1192/BuilderEntityExisting.java
@@ -177,11 +177,13 @@ public class BuilderEntityExisting extends ABuilderEntityBase {
             if (lastExplosionPosition != null && source.isExplosion()) {
                 //We encountered an explosion.  These may or may not have have entities linked to them.  Depends on if
                 //it's a player firing a gun that had a bullet, or a random TNT lighting in the world.
-                //Explosions, unlike other damage sources, can hit multiple collision boxes on an entity at once.
+                //Explosions can hit multiple boxes at once.  Apply damage once to the core entity to prevent
+                //parts from forwarding duplicate explosive damage back into the same vehicle.
                 BoundingBox explosiveBounds = new BoundingBox(lastExplosionPosition, amount, amount, amount);
                 for (BoundingBox box : interactAttackBoxes.getBoxes()) {
                     if (box.intersects(explosiveBounds)) {
-                        multipart.attack(new Damage(amount, box, null, playerSource, null).setExplosive());
+                        multipart.attack(new Damage(amount, null, null, playerSource, null).setExplosive());
+                        break;
                     }
                 }
                 lastExplosionPosition = null;

--- a/mcinterfaceforge1201/src/main/java/mcinterface1201/BuilderEntityExisting.java
+++ b/mcinterfaceforge1201/src/main/java/mcinterface1201/BuilderEntityExisting.java
@@ -183,7 +183,7 @@ public class BuilderEntityExisting extends ABuilderEntityBase {
                 BoundingBox explosiveBounds = new BoundingBox(lastExplosionPosition, amount, amount, amount);
                 for (BoundingBox box : interactAttackBoxes.getBoxes()) {
                     if (box.intersects(explosiveBounds)) {
-                        multipart.attack(new Damage(amount, null, null, playerSource, null).setExplosive());
+                        multipart.attack(new Damage(amount * ConfigSystem.settings.damage.externalExplosionDamageFactor.value, null, null, playerSource, null).setExplosive());
                         break;
                     }
                 }

--- a/mcinterfaceforge1201/src/main/java/mcinterface1201/BuilderEntityExisting.java
+++ b/mcinterfaceforge1201/src/main/java/mcinterface1201/BuilderEntityExisting.java
@@ -178,11 +178,13 @@ public class BuilderEntityExisting extends ABuilderEntityBase {
             if (lastExplosionPosition != null && source.is(DamageTypeTags.IS_EXPLOSION)) {
                 //We encountered an explosion.  These may or may not have have entities linked to them.  Depends on if
                 //it's a player firing a gun that had a bullet, or a random TNT lighting in the world.
-                //Explosions, unlike other damage sources, can hit multiple collision boxes on an entity at once.
+                //Explosions can hit multiple boxes at once.  Apply damage once to the core entity to prevent
+                //parts from forwarding duplicate explosive damage back into the same vehicle.
                 BoundingBox explosiveBounds = new BoundingBox(lastExplosionPosition, amount, amount, amount);
                 for (BoundingBox box : interactAttackBoxes.getBoxes()) {
                     if (box.intersects(explosiveBounds)) {
-                        multipart.attack(new Damage(amount, box, null, playerSource, null).setExplosive());
+                        multipart.attack(new Damage(amount, null, null, playerSource, null).setExplosive());
+                        break;
                     }
                 }
                 lastExplosionPosition = null;


### PR DESCRIPTION
check if damage is explosive, then only apply to core vehicle and skip dmg forwarding