### PR TITLE
Fixed tiny item scanner preview

### DIFF
--- a/mcinterfaceneoforge1211/src/main/java/mcinterface1211/InterfaceRender.java
+++ b/mcinterfaceneoforge1211/src/main/java/mcinterface1211/InterfaceRender.java
@@ -636,11 +636,14 @@ public class InterfaceRender implements IInterfaceRender {
                     posestack.translate(0, 0, (float) (component.translation.z - 100));
                     if (component.scale != 1.0) {
                         posestack.scale(component.scale, component.scale, 1.0F);
+						RenderSystem.applyModelViewMatrix();
                         mcGUI.renderItem(((WrapperItemStack) component.stackToRender).stack, (int) (component.translation.x / component.scale), (int) (-component.translation.y / component.scale) + 1);
                     } else {
+						RenderSystem.applyModelViewMatrix();
                         mcGUI.renderItem(((WrapperItemStack) component.stackToRender).stack, (int) component.translation.x, (int) -component.translation.y);
                     }
                     posestack.popMatrix();
+					RenderSystem.applyModelViewMatrix();
                 }
             }
             stacksToRender.clear();


### PR DESCRIPTION
The queued GUI item renderer now calls RenderSystem.applyModelViewMatrix() after applying the item scale/translation and again after popping it, so the part scanner preview renders at the intended size above the info box instead of as a tiny vanilla item near the top-left.

<img width="900" height="500" alt="2026_04_19_0rw_Kleki" src="https://github.com/user-attachments/assets/aacf6f08-2206-4f77-8062-1400493645f5" />
<img width="1708" height="960" alt="2026_04_19_0rx_Kleki" src="https://github.com/user-attachments/assets/d0dc0f1c-e878-4822-9d25-908f39d3d3e6" />
