### PR TITLE
New "guiTextObjects":[] Function + Collision Group Hover Variable Tweaks

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
@@ -86,6 +86,10 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
      * Map containing text lines for saved text provided by this entity.
      **/
     public final Map<JSONText, String> text = new LinkedHashMap<>();
+    //GUI text objects keep their own animation and fade state as they are rendered independently from model text.
+    public final Map<JSONText, AnimationSwitchbox> guiTextSwitchboxes = new LinkedHashMap<>();
+    private final Map<JSONText, Double> guiTextAlphaValues = new HashMap<>();
+    private final Map<JSONText, Double> guiTextLastSampleTimes = new HashMap<>();
 
     /**
      * Map of computed variables.  These are computed using logic and need to be re-created on core entity makeup changes.
@@ -171,6 +175,7 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
     };
 
     public static final String REPAIRED_NAME = "repaired";
+    private static final int DEFAULT_GUI_TEXT_FADE_TICKS = 7;
 
     /**
      * Constructor for synced entities
@@ -326,6 +331,15 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
                     }
                 }
             }
+
+            if (definition.rendering.guiTextObjects != null) {
+                for (JSONText guiTextDef : definition.rendering.guiTextObjects) {
+                    if (guiTextDef.animations != null) {
+                        //GUI text only uses the switchbox result for visibility, but keeps the normal animation syntax.
+                        guiTextSwitchboxes.put(guiTextDef, new AnimationSwitchbox(this, guiTextDef.animations, null));
+                    }
+                }
+            }
         }
     }
 
@@ -413,13 +427,7 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
             for (Entry<JSONText, String> textEntry : text.entrySet()) {
                 JSONText textDef = textEntry.getKey();
                 if (textDef.variableName != null) {
-                    String value = getRawTextVariableValue(textDef, 0);
-                    if (value != null) {
-                        value = String.format(textDef.variableFormat, value);
-                    } else {
-                        value = String.format(textDef.variableFormat, getOrCreateVariable(textDef.variableName).computeValue(0) * textDef.variableFactor + textDef.variableOffset);
-                    }
-                    textEntry.setValue(value);
+                    textEntry.setValue(formatTextValue(textDef, textEntry.getValue(), 0));
                 }
             }
         }
@@ -540,6 +548,31 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
                 textEntry.setValue(textValue);
             }
         }
+    }
+
+    //Shared text formatting logic keeps GUI text and world text behaving the same for variables and custom text sources.
+    private String formatTextValue(JSONText textDef, String currentTextValue, float partialTicks) {
+        if (textDef.variableName != null) {
+            String value = getRawTextVariableValue(textDef, partialTicks);
+            if (value != null) {
+                return String.format(textDef.variableFormat, value);
+            } else {
+                return String.format(textDef.variableFormat, getOrCreateVariable(textDef.variableName).computeValue(partialTicks) * textDef.variableFactor + textDef.variableOffset);
+            }
+        } else {
+            return currentTextValue != null ? currentTextValue : textDef.defaultText;
+        }
+    }
+
+    private String getCurrentTextValue(JSONText textDef) {
+        if (textDef.fieldName != null) {
+            for (Entry<JSONText, String> textEntry : text.entrySet()) {
+                if (textDef.fieldName.equals(textEntry.getKey().fieldName)) {
+                    return textEntry.getValue();
+                }
+            }
+        }
+        return textDef.defaultText;
     }
 
     /**
@@ -1064,6 +1097,51 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
      */
     public String getRawTextVariableValue(JSONText textDef, float partialTicks) {
         return null;
+    }
+
+    /**
+     * Returns the text value for the passed-in GUI text definition.
+     * This mirrors the standard text object formatting so pack authors can reuse the same text settings.
+     */
+    public String getGUITextValue(JSONText textDef, float partialTicks) {
+        return formatTextValue(textDef, getCurrentTextValue(textDef), partialTicks);
+    }
+
+    /**
+     * Returns the current alpha for the passed-in GUI text object after updating its fade timers.
+     */
+    public float getGUITextAlpha(JSONText textDef, boolean shouldShow, float partialTicks) {
+        AnimationSwitchbox switchbox = guiTextSwitchboxes.get(textDef);
+        if (switchbox != null) {
+            shouldShow = shouldShow && switchbox.runSwitchbox(partialTicks, false);
+        }
+
+        double currentTime = ticksExisted + partialTicks;
+        double lastSampleTime = guiTextLastSampleTimes.containsKey(textDef) ? guiTextLastSampleTimes.get(textDef) : currentTime;
+        double deltaTime = Math.max(0.0, currentTime - lastSampleTime);
+        double alpha = guiTextAlphaValues.getOrDefault(textDef, 0.0);
+        int fadeTime = shouldShow ? textDef.fadeInTime : textDef.fadeOutTime;
+        if (fadeTime <= 0) {
+            fadeTime = DEFAULT_GUI_TEXT_FADE_TICKS;
+        }
+
+        alpha += (shouldShow ? deltaTime : -deltaTime) / fadeTime;
+        if (alpha < 0.0) {
+            alpha = 0.0;
+        } else if (alpha > 1.0) {
+            alpha = 1.0;
+        }
+
+        guiTextAlphaValues.put(textDef, alpha);
+        guiTextLastSampleTimes.put(textDef, currentTime);
+        return (float) alpha;
+    }
+
+    /**
+     * Returns true if this entity actually defines any screen-space GUI text.
+     */
+    public boolean hasGUIText() {
+        return definition.rendering != null && definition.rendering.guiTextObjects != null && !definition.rendering.guiTextObjects.isEmpty();
     }
 
     /**

--- a/mccore/src/main/java/minecrafttransportsimulator/guis/components/AGUIBase.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/guis/components/AGUIBase.java
@@ -196,6 +196,9 @@ public abstract class AGUIBase {
             }
         }
 
+        //Allow GUIs to render dynamic overlay content that doesn't map cleanly to static components.
+        renderCustomElements(mouseX, mouseY, blendingEnabled, partialTicks);
+
         //Render any tooltips.  These only render on non-blended passes.
         if (!blendingEnabled) {
             for (AGUIComponent component : components) {
@@ -204,6 +207,9 @@ public abstract class AGUIBase {
                 }
             }
         }
+    }
+
+    protected void renderCustomElements(int mouseX, int mouseY, boolean blendingEnabled, float partialTicks) {
     }
 
     /**

--- a/mccore/src/main/java/minecrafttransportsimulator/guis/instances/GUIOverlay.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/guis/instances/GUIOverlay.java
@@ -1,6 +1,8 @@
 package minecrafttransportsimulator.guis.instances;
 
 import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -9,8 +11,10 @@ import minecrafttransportsimulator.baseclasses.ColorRGB;
 import minecrafttransportsimulator.baseclasses.EntityInteractResult;
 import minecrafttransportsimulator.baseclasses.Point3D;
 import minecrafttransportsimulator.entities.components.AEntityB_Existing;
+import minecrafttransportsimulator.entities.components.AEntityD_Definable;
 import minecrafttransportsimulator.entities.components.AEntityE_Interactable;
 import minecrafttransportsimulator.entities.components.AEntityF_Multipart;
+import minecrafttransportsimulator.entities.instances.APart;
 import minecrafttransportsimulator.entities.instances.EntityPlayerGun;
 import minecrafttransportsimulator.entities.instances.PartInteractable;
 import minecrafttransportsimulator.entities.instances.PartSeat;
@@ -21,9 +25,11 @@ import minecrafttransportsimulator.items.components.AItemPack;
 import minecrafttransportsimulator.items.components.AItemPart;
 import minecrafttransportsimulator.jsondefs.JSONItem.ItemComponentType;
 import minecrafttransportsimulator.jsondefs.JSONPartDefinition;
+import minecrafttransportsimulator.jsondefs.JSONText;
 import minecrafttransportsimulator.mcinterface.IWrapperPlayer;
 import minecrafttransportsimulator.mcinterface.InterfaceManager;
 import minecrafttransportsimulator.packloading.PackParser;
+import minecrafttransportsimulator.rendering.RenderText;
 import minecrafttransportsimulator.rendering.RenderText.TextAlignment;
 import minecrafttransportsimulator.sound.SoundInstance;
 import minecrafttransportsimulator.systems.CameraSystem;
@@ -42,6 +48,8 @@ public class GUIOverlay extends AGUIBase {
     private EntityInteractResult lastInteractResult;
     private AEntityE_Interactable<?> lastCollisionGroupHoverEntity;
     private int lastCollisionGroupHoverIndex;
+    private int lastCollisionBoxHoverIndex;
+    private final LinkedHashSet<AEntityD_Definable<?>> trackedGUITextEntities = new LinkedHashSet<>();
 
     @Override
     public void setupComponents() {
@@ -115,15 +123,31 @@ public class GUIOverlay extends AGUIBase {
         }
         
         int hoveredCollisionGroupIndex = getCollisionGroupIndex(interactResult);
-        if (lastCollisionGroupHoverEntity != null && (interactResult == null || interactResult.entity != lastCollisionGroupHoverEntity || hoveredCollisionGroupIndex != lastCollisionGroupHoverIndex)) {
-            lastCollisionGroupHoverEntity.getOrCreateVariable("collision_" + lastCollisionGroupHoverIndex + "_player_cursor_hovered").setActive(false, false);
-            lastCollisionGroupHoverEntity = null;
-            lastCollisionGroupHoverIndex = 0;
+        int hoveredCollisionBoxIndex = getCollisionBoxIndex(interactResult);
+        boolean collisionGroupHoverChanged = interactResult == null || interactResult.entity != lastCollisionGroupHoverEntity || hoveredCollisionGroupIndex != lastCollisionGroupHoverIndex;
+        boolean collisionBoxHoverChanged = collisionGroupHoverChanged || hoveredCollisionBoxIndex != lastCollisionBoxHoverIndex;
+        if (lastCollisionGroupHoverEntity != null) {
+            if (collisionBoxHoverChanged && lastCollisionBoxHoverIndex > 0) {
+                //Box indexes are 1-based and follow the order of the collision entries in the hovered group.
+                lastCollisionGroupHoverEntity.getOrCreateVariable("collision_" + lastCollisionGroupHoverIndex + "_" + lastCollisionBoxHoverIndex + "_player_cursor_hovered").setActive(false, false);
+                lastCollisionBoxHoverIndex = 0;
+            }
+            if (collisionGroupHoverChanged) {
+                lastCollisionGroupHoverEntity.getOrCreateVariable("collision_" + lastCollisionGroupHoverIndex + "_player_cursor_hovered").setActive(false, false);
+                lastCollisionGroupHoverEntity = null;
+                lastCollisionGroupHoverIndex = 0;
+            }
         }
-        if (lastCollisionGroupHoverEntity == null && interactResult != null && hoveredCollisionGroupIndex > 0) {
-            interactResult.entity.getOrCreateVariable("collision_" + hoveredCollisionGroupIndex + "_player_cursor_hovered").setActive(true, false);
-            lastCollisionGroupHoverEntity = interactResult.entity;
-            lastCollisionGroupHoverIndex = hoveredCollisionGroupIndex;
+        if (interactResult != null && hoveredCollisionGroupIndex > 0) {
+            if (lastCollisionGroupHoverEntity == null) {
+                interactResult.entity.getOrCreateVariable("collision_" + hoveredCollisionGroupIndex + "_player_cursor_hovered").setActive(true, false);
+                lastCollisionGroupHoverEntity = interactResult.entity;
+                lastCollisionGroupHoverIndex = hoveredCollisionGroupIndex;
+            }
+            if (collisionBoxHoverChanged && hoveredCollisionBoxIndex > 0) {
+                interactResult.entity.getOrCreateVariable("collision_" + hoveredCollisionGroupIndex + "_" + hoveredCollisionBoxIndex + "_player_cursor_hovered").setActive(true, false);
+            }
+            lastCollisionBoxHoverIndex = hoveredCollisionBoxIndex;
         }
         
         mouseoverLabel.text = "";
@@ -236,14 +260,93 @@ public class GUIOverlay extends AGUIBase {
     }
 
     @Override
+    protected void renderCustomElements(int mouseX, int mouseY, boolean blendingEnabled, float partialTicks) {
+        if (!blendingEnabled || InterfaceManager.clientInterface.isGUIHidden()) {
+            return;
+        }
+
+        LinkedHashSet<AEntityD_Definable<?>> currentGUITextEntities = new LinkedHashSet<>();
+        IWrapperPlayer player = InterfaceManager.clientInterface.getClientPlayer();
+        addGUITextEntityChain(currentGUITextEntities, player.getEntityRiding());
+        if (lastInteractResult != null) {
+            addGUITextEntityChain(currentGUITextEntities, lastInteractResult.entity);
+        }
+
+        trackedGUITextEntities.addAll(currentGUITextEntities);
+        int entityLayer = 0;
+        Iterator<AEntityD_Definable<?>> iterator = trackedGUITextEntities.iterator();
+        while (iterator.hasNext()) {
+            AEntityD_Definable<?> entity = iterator.next();
+            if (!entity.isValid || !entity.hasGUIText()) {
+                iterator.remove();
+                continue;
+            }
+
+            boolean isCurrentEntity = currentGUITextEntities.contains(entity);
+            boolean shouldKeepTracking = isCurrentEntity;
+            for (JSONText textDef : entity.definition.rendering.guiTextObjects) {
+                float alpha = entity.getGUITextAlpha(textDef, isCurrentEntity, partialTicks);
+                if (alpha <= 0.0F) {
+                    continue;
+                }
+
+                String textValue = entity.getGUITextValue(textDef, partialTicks);
+                if (textValue == null || textValue.isEmpty()) {
+                    continue;
+                }
+
+                //Each tracked entity gets a small Z slice so multiple prompts can overlap without fighting.
+                RenderText.drawGUIText(textValue, entity, textDef, screenWidth, screenHeight, 325 + entityLayer * 5D, alpha);
+                shouldKeepTracking = true;
+            }
+
+            if (!shouldKeepTracking) {
+                iterator.remove();
+            } else {
+                ++entityLayer;
+            }
+        }
+    }
+
+    @Override
     protected String getTexture() {
         return CameraSystem.customCameraOverlay;
+    }
+
+    private void addGUITextEntityChain(LinkedHashSet<AEntityD_Definable<?>> entities, AEntityB_Existing startEntity) {
+        AEntityB_Existing entity = startEntity;
+        while (entity instanceof APart) {
+            if (entity instanceof AEntityD_Definable<?>) {
+                AEntityD_Definable<?> definable = (AEntityD_Definable<?>) entity;
+                if (definable.hasGUIText()) {
+                    entities.add(definable);
+                }
+            }
+            entity = ((APart) entity).entityOn;
+        }
+
+        if (entity instanceof AEntityD_Definable<?>) {
+            AEntityD_Definable<?> definable = (AEntityD_Definable<?>) entity;
+            if (definable.hasGUIText()) {
+                entities.add(definable);
+            }
+        }
     }
 
    
     private static int getCollisionGroupIndex(EntityInteractResult interactResult) {
         if (interactResult != null && interactResult.box.groupDef != null && interactResult.entity.definition.collisionGroups != null) {
             return interactResult.entity.definition.collisionGroups.indexOf(interactResult.box.groupDef) + 1;
+        }
+        return 0;
+    }
+
+    private static int getCollisionBoxIndex(EntityInteractResult interactResult) {
+        if (interactResult != null && interactResult.box.groupDef != null && interactResult.entity.definition.collisionGroups != null) {
+            int groupIndex = interactResult.entity.definition.collisionGroups.indexOf(interactResult.box.groupDef);
+            if (groupIndex >= 0 && interactResult.entity.definitionCollisionBoxes.size() > groupIndex) {
+                return interactResult.entity.definitionCollisionBoxes.get(groupIndex).indexOf(interactResult.box) + 1;
+            }
         }
         return 0;
     }

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONRendering.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONRendering.java
@@ -12,6 +12,9 @@ public class JSONRendering {
     @JSONDescription("Text objects are used to render text on models.  This can be used for license plates on cars, tail numbers on planes, status information on fuel pumps, etc.  Every entry is its own text section, and therefore you can have multiple objects for different things.  For example, you may want to make a bus with light-up route signs with multiple characters, but also with two license plates that are limited to 7 characters.")
     public List<JSONText> textObjects;
 
+    @JSONDescription("GUI text objects render in screen-space for the local player rather than on the model itself.  These use the same text parameters as textObjects, but pos is measured in screen pixels relative to the screen center, positive X moves right, positive Y moves down, scale 1 matches the standard GUI font size, and animations control when the text fades in or out on-screen.")
+    public List<JSONText> guiTextObjects;
+
     @JSONDescription("Animated objects are the most complex part of rendering and will likely result in a few pack reloads before you get them right.  However, they are a powerful system that allows any type of rotation, including multi-axis for things like driveshafts and steering assemblies. The animated objects section is composed of a few fields, and a listing of one or more animations to apply on the object.  Objects require no special naming in the model, though some objects may require special names to work with other systems.  For example, a light would have to be named according to the light convention, but could also be specified in this section to rotate it.")
     public List<JSONAnimatedObject> animatedObjects;
 

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONText.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONText.java
@@ -1,5 +1,7 @@
 package minecrafttransportsimulator.jsondefs;
 
+import java.util.List;
+
 import minecrafttransportsimulator.baseclasses.ColorRGB;
 import minecrafttransportsimulator.baseclasses.Point3D;
 import minecrafttransportsimulator.baseclasses.RotationMatrix;
@@ -43,8 +45,7 @@ public class JSONText {
     @JSONDescription("The default text to display.  This is what the field will have when the model is first placed down, and will persist until a player changes it.  Required, but may be blank.")
     public String defaultText;
 
-    @JSONRequired
-    @JSONDescription("The max number of characters this entry can have.")
+    @JSONDescription("The max number of characters this entry can have.  Required for editable world text, but optional for guiTextObjects and variable-driven text.")
     public int maxLength;
 
     @JSONRequired
@@ -68,4 +69,13 @@ public class JSONText {
 
     @JSONDescription("If true, this text will be auto-scaled to fit inside the wrapWidth rather than actually wrapping to another line.  Has no affect unless you specify a wrapWidth!")
     public boolean autoScale;
+
+    @JSONDescription("Optional animation list for guiTextObjects.  These are normally visibility checks that decide when the text should be shown on-screen.")
+    public List<JSONAnimationDefinition> animations;
+
+    @JSONDescription("Fade-in time for guiTextObjects, in ticks.  If not set, a default of 7 ticks is used.")
+    public int fadeInTime;
+
+    @JSONDescription("Fade-out time for guiTextObjects, in ticks.  If not set, a default of 7 ticks is used.")
+    public int fadeOutTime;
 }

--- a/mccore/src/main/java/minecrafttransportsimulator/rendering/RenderText.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/rendering/RenderText.java
@@ -53,10 +53,17 @@ public class RenderText {
      * This allows for proper normal calculations to prevent needing to re-normalize the text.
      */
     public static void drawText(String text, String fontName, Point3D position, ColorRGB color, TextAlignment alignment, float scale, boolean autoScale, int wrapWidth, boolean renderLit, int worldLightValue) {
+        drawText(text, fontName, position, color, alignment, scale, autoScale, wrapWidth, renderLit, worldLightValue, 1.0F);
+    }
+
+    /**
+     * Alpha-aware variant of {@link #drawText(String, String, Point3D, ColorRGB, TextAlignment, float, boolean, int, boolean, int)}.
+     */
+    public static void drawText(String text, String fontName, Point3D position, ColorRGB color, TextAlignment alignment, float scale, boolean autoScale, int wrapWidth, boolean renderLit, int worldLightValue, float alpha) {
         if (!text.isEmpty()) {
             transformHelper.resetTransforms();
             transformHelper.applyTranslation(position);
-            getFontData(fontName).renderText(text, transformHelper, null, alignment, scale, autoScale, wrapWidth, true, color, renderLit, worldLightValue, true);
+            getFontData(fontName).renderText(text, transformHelper, null, alignment, scale, autoScale, wrapWidth, true, color, renderLit, worldLightValue, true, alpha);
         }
     }
 
@@ -65,6 +72,13 @@ public class RenderText {
      * Essentially, this is JSON-defined rendering rather than manual entry of points.
      */
     public static void draw3DText(String text, AEntityD_Definable<?> entity, TransformationMatrix transform, JSONText definition, boolean pixelCoords, boolean renderLit) {
+        draw3DText(text, entity, transform, definition, pixelCoords, renderLit, 1.0F);
+    }
+
+    /**
+     * Alpha-aware variant of {@link #draw3DText(String, AEntityD_Definable, TransformationMatrix, JSONText, boolean, boolean)}.
+     */
+    public static void draw3DText(String text, AEntityD_Definable<?> entity, TransformationMatrix transform, JSONText definition, boolean pixelCoords, boolean renderLit, float alpha) {
         if (!text.isEmpty()) {
             //Get the actual color we will need to render with based on JSON.
             ColorRGB color = entity.getTextColor(definition.inheritedColorIndex, definition.color);
@@ -72,7 +86,21 @@ public class RenderText {
             //Render the text.
             transformHelper.set(transform);
             transformHelper.applyTranslation(definition.pos);
-            getFontData(definition.fontName).renderText(text, transformHelper, definition.rot, TextAlignment.values()[definition.renderPosition], definition.scale, definition.autoScale, definition.wrapWidth, pixelCoords, color, renderLit, entity.worldLightValue, false);
+            getFontData(definition.fontName).renderText(text, transformHelper, definition.rot, TextAlignment.values()[definition.renderPosition], definition.scale, definition.autoScale, definition.wrapWidth, pixelCoords, color, renderLit, entity.worldLightValue, false, alpha);
+        }
+    }
+
+    /**
+     * Renders a JSON text definition directly on the player's screen.
+     * GUI text uses screen-center-relative pixel coordinates, so Y is inverted before rendering.
+     */
+    public static void drawGUIText(String text, AEntityD_Definable<?> entity, JSONText definition, int screenWidth, int screenHeight, double zOffset, float alpha) {
+        if (!text.isEmpty()) {
+            ColorRGB color = entity.getTextColor(definition.inheritedColorIndex, definition.color);
+            transformHelper.resetTransforms();
+            transformHelper.applyTranslation(screenWidth / 2D, -screenHeight / 2D, zOffset);
+            transformHelper.applyTranslation(definition.pos.x, -definition.pos.y, definition.pos.z);
+            getFontData(definition.fontName).renderText(text, transformHelper, definition.rot, TextAlignment.values()[definition.renderPosition], definition.scale, definition.autoScale, definition.wrapWidth, true, color, true, entity.worldLightValue, true, alpha);
         }
     }
 
@@ -337,7 +365,7 @@ public class RenderText {
             this.charTopOffset = charTopOffset;
         }
 
-        private void renderText(String text, TransformationMatrix transform, RotationMatrix rotation, TextAlignment alignment, float scale, boolean autoScale, int wrapWidth, boolean pixelCoords, ColorRGB color, boolean renderLit, int worldLightValue, boolean onGUI) {
+        private void renderText(String text, TransformationMatrix transform, RotationMatrix rotation, TextAlignment alignment, float scale, boolean autoScale, int wrapWidth, boolean pixelCoords, ColorRGB color, boolean renderLit, int worldLightValue, boolean onGUI, float alpha) {
             //Clear out the active object list as it was set last pass.
             for (RenderableData object : activeRenderObjects) {
                 object.vertexObject.vertices.clear();
@@ -672,6 +700,7 @@ public class RenderText {
             for (RenderableData object : activeRenderObjects) {
                 object.setLightValue(worldLightValue);
                 object.setLightMode(renderLit ? LightingMode.IGNORE_ALL_LIGHTING : (onGUI ? LightingMode.IGNORE_ORIENTATION_LIGHTING : LightingMode.NORMAL));
+                object.setAlpha(alpha);
                 object.transform.set(transform);
                 if (rotation != null) {
                     object.transform.applyRotation(rotation);

--- a/mcinterfaceforge1122/src/main/java/mcinterface1122/InterfaceClient.java
+++ b/mcinterfaceforge1122/src/main/java/mcinterface1122/InterfaceClient.java
@@ -1,94 +1,172 @@
-package mcinterface1122;
+package mcinterface1211;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
 import minecrafttransportsimulator.baseclasses.Point3D;
+import minecrafttransportsimulator.entities.instances.EntityFluidTank;
 import minecrafttransportsimulator.guis.components.AGUIBase;
 import minecrafttransportsimulator.guis.instances.GUIPackMissing;
+import minecrafttransportsimulator.items.components.AItemPack;
+import minecrafttransportsimulator.items.components.AItemSubTyped;
+import minecrafttransportsimulator.jsondefs.AJSONMultiModelProvider;
+import minecrafttransportsimulator.mcinterface.AWrapperWorld;
 import minecrafttransportsimulator.mcinterface.IInterfaceClient;
 import minecrafttransportsimulator.mcinterface.IWrapperItemStack;
 import minecrafttransportsimulator.mcinterface.IWrapperPlayer;
 import minecrafttransportsimulator.mcinterface.InterfaceManager;
 import minecrafttransportsimulator.packloading.PackParser;
+import minecrafttransportsimulator.rendering.AModelParser;
+import minecrafttransportsimulator.rendering.RenderText;
 import minecrafttransportsimulator.systems.CameraSystem.CameraMode;
 import minecrafttransportsimulator.systems.ConfigSystem;
 import minecrafttransportsimulator.systems.ControlSystem;
-import net.minecraft.block.SoundType;
+import minecrafttransportsimulator.systems.LanguageSystem;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.CameraType;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.ScaledResolution;
-import net.minecraft.client.renderer.ActiveRenderInfo;
-import net.minecraft.client.util.ITooltipFlag;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.SoundCategory;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Vec3d;
-import net.minecraft.util.text.TextFormatting;
-import net.minecraftforge.fluids.Fluid;
-import net.minecraftforge.fluids.FluidRegistry;
-import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fml.common.FMLCommonHandler;
-import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.gameevent.TickEvent;
-import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
-import net.minecraftforge.fml.relauncher.Side;
+import net.minecraft.client.gui.screens.ChatScreen;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
+import net.minecraft.network.chat.TextColor;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.phys.Vec3;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.minecraft.core.registries.BuiltInRegistries;
 
-@EventBusSubscriber(Side.CLIENT)
+@EventBusSubscriber(modid = InterfaceLoader.MODID, value = Dist.CLIENT)
 public class InterfaceClient implements IInterfaceClient {
     private static CameraMode actualCameraMode;
     private static CameraMode cameraModeRequest;
     private static int ticksToCullingWarning = 200;
-    private static BuilderEntityRenderForwarder activeFollower;
-    private static int ticksSincePlayerJoin;
+
+    /**Model preloading state — spreads parsing across ticks to avoid a single big freeze.*/
+    private static List<String> modelsToPreload = null;
+    private static int preloadIndex = 0;
+    private static final int MODELS_PER_TICK = 3;
+
+    /**
+     * Initiates model preloading by collecting all unique model locations from loaded packs.
+     * Actual parsing is spread across subsequent client ticks via tickModelPreload().
+     */
+    private static void initModelPreload() {
+        if (modelsToPreload != null) {
+            return; //Already started or finished.
+        }
+        Set<String> uniqueLocations = new HashSet<>();
+        for (AItemPack<?> item : PackParser.getAllPackItems()) {
+            if (item instanceof AItemSubTyped) {
+                AItemSubTyped<?> subTypedItem = (AItemSubTyped<?>) item;
+                if (subTypedItem.definition instanceof AJSONMultiModelProvider) {
+                    try {
+                        String modelLocation = ((AJSONMultiModelProvider) subTypedItem.definition).getModelLocation(subTypedItem.subDefinition);
+                        if (modelLocation != null) {
+                            uniqueLocations.add(modelLocation);
+                        }
+                    } catch (Exception ignored) {}
+                }
+            }
+        }
+        modelsToPreload = new ArrayList<>(uniqueLocations);
+        preloadIndex = 0;
+        InterfaceManager.coreInterface.logError("MTS model preload: " + modelsToPreload.size() + " unique models queued.");
+    }
+
+    /**
+     * Parses a few models per tick on the main thread.  This avoids thread-safety issues
+     * with AModelParser's HashMap cache while spreading the work to prevent a single big stutter.
+     */
+    private static void tickModelPreload() {
+        if (modelsToPreload == null || preloadIndex >= modelsToPreload.size()) {
+            return;
+        }
+        int end = Math.min(preloadIndex + MODELS_PER_TICK, modelsToPreload.size());
+        for (int i = preloadIndex; i < end; i++) {
+            try {
+                AModelParser.parseModel(modelsToPreload.get(i), true);
+            } catch (Exception ignored) {
+                //Skip models that fail — they'll error at render time.
+            }
+        }
+        preloadIndex = end;
+        if (preloadIndex >= modelsToPreload.size()) {
+            InterfaceManager.coreInterface.logError("MTS model preload complete: " + modelsToPreload.size() + " models cached.");
+        }
+    }
 
     @Override
     public boolean isGamePaused() {
-        return Minecraft.getMinecraft().isGamePaused();
+        return Minecraft.getInstance().isPaused();
     }
 
     @Override
     public String getLanguageName() {
-        return Minecraft.getMinecraft().gameSettings.language;
+        if (Minecraft.getInstance().getLanguageManager() != null) {
+            return Minecraft.getInstance().getLanguageManager().getSelected();
+        } else {
+            return "en_us";
+        }
     }
 
     @Override
     public List<String> getAllLanguages() {
         List<String> list = new ArrayList<>();
-        Minecraft.getMinecraft().getLanguageManager().getLanguages().forEach(language -> list.add(language.getLanguageCode()));
+        Minecraft.getInstance().getLanguageManager().getLanguages().forEach((languageCode, languageInfo) -> list.add(languageCode));
         return list;
     }
 
     @Override
     public String getFluidName(String fluidID, String fluidMod) {
-        Fluid fluid = FluidRegistry.getFluid(fluidID);
-        return fluid != null ? new FluidStack(fluid, 1).getLocalizedName() : "INVALID";
+        for (Entry<ResourceKey<Fluid>, Fluid> fluidEntry : BuiltInRegistries.FLUID.entrySet()) {
+            ResourceLocation fluidLocation = fluidEntry.getKey().location();
+            if ((fluidMod.equals(EntityFluidTank.WILDCARD_FLUID_MOD) || fluidLocation.getNamespace().equals(fluidMod)) && fluidLocation.getPath().equals(fluidID)) {
+                return fluidEntry.getValue().getFluidType().getDescription().getString();
+            }
+        }
+        return "INVALID";
     }
 
     @Override
     public Map<String, String> getAllFluidNames() {
         Map<String, String> fluidIDsToNames = new HashMap<>();
-        for (String fluidID : FluidRegistry.getRegisteredFluids().keySet()) {
-            fluidIDsToNames.put(fluidID, new FluidStack(FluidRegistry.getFluid(fluidID), 1).getLocalizedName());
+        for (Fluid fluid : BuiltInRegistries.FLUID) {
+            fluidIDsToNames.put(BuiltInRegistries.FLUID.getKey(fluid).getPath(), new FluidStack(fluid, 1).getDisplayName().getString());
         }
         return fluidIDsToNames;
     }
 
     @Override
     public boolean isChatOpen() {
-        return Minecraft.getMinecraft().ingameGUI.getChatGUI().getChatOpen();
+        return Minecraft.getInstance().screen instanceof ChatScreen;
     }
 
     @Override
     public boolean isGUIOpen() {
-        return Minecraft.getMinecraft().currentScreen != null;
+        return Minecraft.getInstance().screen != null;
     }
 
     @Override
+    public boolean isGUIHidden() {
+        return Minecraft.getInstance().options.hideGui;
+    }
+
     public void displayOverlayMessage(String message) {
-        Minecraft.getMinecraft().ingameGUI.setOverlayMessage(message, false);
+        Minecraft.getInstance().gui.setOverlayMessage(Component.literal(message), false);
     }
 
     @Override
@@ -103,61 +181,63 @@ public class InterfaceClient implements IInterfaceClient {
 
     @Override
     public int getCameraDefaultZoom() {
-        return 4;
+        return 0;
     }
 
     @Override
     public long getPackedDisplaySize() {
-        ScaledResolution screenResolution = new ScaledResolution(Minecraft.getMinecraft());
-        return (((long) screenResolution.getScaledWidth()) << Integer.SIZE) | (screenResolution.getScaledHeight() & 0xffffffffL);
-    }
-
-    @Override
-    public float getMouseSensitivity() {
-        return Minecraft.getMinecraft().gameSettings.mouseSensitivity;
-    }
-
-    @Override
-    public void setMouseSensitivity(float setting) {
-        Minecraft.getMinecraft().gameSettings.mouseSensitivity = setting;
+        return (((long) Minecraft.getInstance().getWindow().getGuiScaledWidth()) << Integer.SIZE) | (Minecraft.getInstance().getWindow().getGuiScaledHeight() & 0xffffffffL);
     }
 
     @Override
     public float getFOV() {
-        return Minecraft.getMinecraft().gameSettings.fovSetting;
+        return Minecraft.getInstance().options.fov().get();
     }
 
     @Override
     public void setFOV(float setting) {
-        Minecraft.getMinecraft().gameSettings.fovSetting = setting;
+        ((Ifov) ((Object) Minecraft.getInstance().options.fov())).setManual((int) setting);
+    }
+
+    //Linked to the OptionInstanceMixin so we can implement a common interface.
+    public static interface Ifov {
+        public void setManual(Integer value);
+    };
+
+    @Override
+    public float getMouseSensitivity() {
+        return Minecraft.getInstance().options.sensitivity().get().floatValue();
+    }
+
+    @Override
+    public void setMouseSensitivity(float setting) {
+        Minecraft.getInstance().options.sensitivity().set((double) setting);
     }
 
     @Override
     public void closeGUI() {
-        Minecraft.getMinecraft().displayGuiScreen(null);
+        Minecraft.getInstance().setScreen(null);
     }
 
     @Override
     public void setActiveGUI(AGUIBase gui) {
-        FMLCommonHandler.instance().showGuiScreen(new BuilderGUI(gui));
+        Minecraft.getInstance().setScreen(new BuilderGUI(gui));
     }
 
     @Override
     public WrapperWorld getClientWorld() {
-        return WrapperWorld.getWrapperFor(Minecraft.getMinecraft().world);
+        return WrapperWorld.getWrapperFor(Minecraft.getInstance().level);
     }
 
     @Override
     public WrapperPlayer getClientPlayer() {
-        EntityPlayer player = Minecraft.getMinecraft().player;
-        return WrapperPlayer.getWrapperFor(player);
+        return WrapperPlayer.getWrapperFor(Minecraft.getInstance().player);
     }
 
     @Override
     public Point3D getCameraPosition() {
-        EntityPlayer player = Minecraft.getMinecraft().player;
-        Vec3d cameraOffset = ActiveRenderInfo.getCameraPosition();
-        mutablePosition.set(player.posX + cameraOffset.x, player.posY + cameraOffset.y, player.posZ + cameraOffset.z);
+        Vec3 cameraOffset = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
+        mutablePosition.set(cameraOffset.x, cameraOffset.y, cameraOffset.z);
         return mutablePosition;
     }
 
@@ -165,19 +245,52 @@ public class InterfaceClient implements IInterfaceClient {
 
     @Override
     public void playBlockBreakSound(Point3D position) {
-        BlockPos pos = new BlockPos(position.x, position.y, position.z);
-        if (!Minecraft.getMinecraft().world.isAirBlock(pos)) {
-            SoundType soundType = Minecraft.getMinecraft().world.getBlockState(pos).getBlock().getSoundType(Minecraft.getMinecraft().world.getBlockState(pos), Minecraft.getMinecraft().player.world, pos, null);
-            Minecraft.getMinecraft().world.playSound(Minecraft.getMinecraft().player, pos, soundType.getBreakSound(), SoundCategory.BLOCKS, soundType.getVolume(), soundType.getPitch());
+        BlockPos pos = BlockPos.containing(position.x, position.y, position.z);
+        if (!Minecraft.getInstance().level.isEmptyBlock(pos)) {
+            SoundType soundType = Minecraft.getInstance().level.getBlockState(pos).getBlock().getSoundType(Minecraft.getInstance().level.getBlockState(pos), Minecraft.getInstance().player.level(), pos, null);
+            Minecraft.getInstance().level.playSound(Minecraft.getInstance().player, pos, soundType.getBreakSound(), SoundSource.BLOCKS, soundType.getVolume(), soundType.getPitch());
         }
     }
 
     @Override
     public List<String> getTooltipLines(IWrapperItemStack stack) {
-        List<String> tooltipText = ((WrapperItemStack) stack).stack.getTooltip(Minecraft.getMinecraft().player, Minecraft.getMinecraft().gameSettings.advancedItemTooltips ? ITooltipFlag.TooltipFlags.ADVANCED : ITooltipFlag.TooltipFlags.NORMAL);
+        List<String> tooltipText = new ArrayList<>();
+        List<Component> tooltipLines = ((WrapperItemStack) stack).stack.getTooltipLines(Item.TooltipContext.EMPTY, Minecraft.getInstance().player, Minecraft.getInstance().options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL);
         //Add grey formatting text to non-first line tooltips.
-        for (int i = 1; i < tooltipText.size(); ++i) {
-            tooltipText.set(i, TextFormatting.GRAY + tooltipText.get(i));
+        for (int i = 0; i < tooltipLines.size(); ++i) {
+            Component component = tooltipLines.get(i);
+            Style style = component.getStyle();
+            String stringToAdd = "";
+            if (style.isBold()) {
+                stringToAdd += RenderText.FORMATTING_CHAR + RenderText.BOLD_FORMATTING_CHAR;
+            }
+            if (style.isItalic()) {
+                stringToAdd += RenderText.FORMATTING_CHAR + RenderText.ITALIC_FORMATTING_CHAR;
+            }
+            if (style.isUnderlined()) {
+                stringToAdd += RenderText.FORMATTING_CHAR + RenderText.UNDERLINE_FORMATTING_CHAR;
+            }
+            if (style.isStrikethrough()) {
+                stringToAdd += RenderText.FORMATTING_CHAR + RenderText.STRIKETHROUGH_FORMATTING_CHAR;
+            }
+            if (style.isObfuscated()) {
+                stringToAdd += RenderText.FORMATTING_CHAR + RenderText.RANDOM_FORMATTING_CHAR;
+            }
+            if (style.getColor() != null) {
+                ChatFormatting legacyColor = null;
+                for (ChatFormatting format : ChatFormatting.values()) {
+                    if (format.isColor()) {
+                        if (style.getColor().equals(TextColor.fromLegacyFormat(format))) {
+                            legacyColor = format;
+                            break;
+                        }
+                    }
+                }
+                if (legacyColor != null) {
+                    stringToAdd += RenderText.FORMATTING_CHAR + Integer.toHexString(legacyColor.ordinal());
+                }
+            }
+            tooltipText.add(stringToAdd + tooltipLines.get(i).getString());
         }
         return tooltipText;
     }
@@ -188,95 +301,86 @@ public class InterfaceClient implements IInterfaceClient {
      * not being called on clients.
      */
     @SubscribeEvent
-    public static void onIVClientTick(TickEvent.ClientTickEvent event) {
+    public static void onIVClientTickPre(net.neoforged.neoforge.client.event.ClientTickEvent.Pre event) {
         IWrapperPlayer player = InterfaceManager.clientInterface.getClientPlayer();
         if (!InterfaceManager.clientInterface.isGamePaused() && player != null) {
-            WrapperWorld world = WrapperWorld.getWrapperFor(Minecraft.getMinecraft().world);
+            AWrapperWorld world = InterfaceManager.clientInterface.getClientWorld();
             if (world != null) {
-                if (event.phase.equals(Phase.START)) {
-                    if (!player.isSpectator()) {
-                        //Handle controls.  This has to happen prior to vehicle updates to ensure click handling is based on current position of the player.
-                        ControlSystem.controlGlobal(player);
-                        if (((WrapperPlayer) player).player.ticksExisted % 100 == 0) {
-                            if (!InterfaceManager.clientInterface.isGUIOpen() && !PackParser.arePacksPresent()) {
-                                new GUIPackMissing();
-                            }
+                //Kick off / continue model preloading across ticks.
+                initModelPreload();
+                tickModelPreload();
+                if (!player.isSpectator()) {
+                    //Handle controls.  This has to happen prior to vehicle updates to ensure click handling is based on current position of the player.
+                    ControlSystem.controlGlobal(player);
+                    if (((WrapperPlayer) player).player.tickCount % 100 == 0) {
+                        if (!InterfaceManager.clientInterface.isGUIOpen() && !PackParser.arePacksPresent()) {
+                            new GUIPackMissing();
                         }
                     }
+                }
 
-                    world.tickAll(true);
+                //Need to update world brightness since sky darken isn't calculated normally on clients.
+                ((WrapperWorld) world).world.updateSkyBrightness();
 
-                    //Complain about compats at 10 second mark.
-                    if (ConfigSystem.settings.general.performModCompatFunctions.value) {
-                        if (ticksToCullingWarning > 0) {
-                            if (--ticksToCullingWarning == 0) {
-                                //Nothing to complain about here!
-                            }
-                        }
-                    }
-
-                    //Check follower.
-                    if (activeFollower != null) {
-                        //Follower exists, check if world is the same and it is actually updating.
-                        //We check basic states, and then the watchdog bit that gets reset every tick.
-                        //This way if we're in the world, but not valid we will know.
-                        EntityPlayer mcPlayer = ((WrapperPlayer) player).player;
-                        if (activeFollower.world != mcPlayer.world || activeFollower.playerFollowing != mcPlayer || mcPlayer.isDead || activeFollower.isDead || activeFollower.idleTickCounter == 20) {
-                            //Follower is not linked.  Remove it and re-create in code below.
-                            activeFollower.setDead();
-                            activeFollower = null;
-                            ticksSincePlayerJoin = 0;
-                        } else {
-                            ++activeFollower.idleTickCounter;
-                        }
-                    } else {
-                        //Follower does not exist, check if player has been present for 3 seconds and spawn it.
-                        if (++ticksSincePlayerJoin == 60) {
-                            activeFollower = new BuilderEntityRenderForwarder(((WrapperPlayer) player).player);
-                            activeFollower.loadedFromSavedNBT = true;
-                            world.world.spawnEntity(activeFollower);
-                        }
-                    }
-                } else {
-                    world.tickAll(false);
+                world.tickAll(true);
                     
-                    //Handle camera requests.
-                    if(cameraModeRequest != null) {
-                    	switch(cameraModeRequest) {
-	                    	case FIRST_PERSON:{
-	                    		Minecraft.getMinecraft().gameSettings.thirdPersonView = 0;
-	                    		break;
-	                    	}
-	                    	case THIRD_PERSON:{
-	                    		Minecraft.getMinecraft().gameSettings.thirdPersonView = 1;
-	                    		break;
-	                    	}
-	                    	case THIRD_PERSON_INVERTED:{
-	                    		Minecraft.getMinecraft().gameSettings.thirdPersonView = 2;
-	                    		break;
-	                    	}
-                    	}
-                    	cameraModeRequest = null;
+                //Complain about Entity Culling mod at 10 second mark.
+                if(ConfigSystem.settings.general.performModCompatFunctions.value && InterfaceManager.coreInterface.isModPresent("entityculling")) {
+                    if(ticksToCullingWarning > 0) {
+                        if(--ticksToCullingWarning == 0) {
+                            player.displayChatMessage(LanguageSystem.SYSTEM_DEBUG, "IV HAS DETECTED THAT ENTITY CULLING MOD IS PRESENT.  THIS MOD CULLS ALL IV VEHICLES UNLESS \"mts:builder_existing\", \"mts:builder_rendering\", AND \"mts:builder_seat\" ARE ADDED TO THE WHITELIST.");
+                        }
                     }
+                }
+            }
+        }
+    }
 
-                    //Update camera state, since this can change depending on tick if we check during renders.
-                    int cameraModeInt = Minecraft.getMinecraft().gameSettings.thirdPersonView;
-                    switch(cameraModeInt) {
-                    	case(0):{
-                    		actualCameraMode = CameraMode.FIRST_PERSON;
-                    		break;
-                    	}
-                    	case(1):{
-                    		actualCameraMode = CameraMode.THIRD_PERSON;
-                    		break;
-                    	}
-                    	case(2):{
-                    		actualCameraMode = CameraMode.THIRD_PERSON_INVERTED;
-                    		break;
-                    	}
+    @SubscribeEvent
+    public static void onIVClientTickPost(net.neoforged.neoforge.client.event.ClientTickEvent.Post event) {
+        IWrapperPlayer player = InterfaceManager.clientInterface.getClientPlayer();
+        if (!InterfaceManager.clientInterface.isGamePaused() && player != null) {
+            AWrapperWorld world = InterfaceManager.clientInterface.getClientWorld();
+            if (world != null) {
+                world.tickAll(false);
+                    
+                //Handle camera requests.
+                if(cameraModeRequest != null) {
+                    switch(cameraModeRequest) {
+                        case FIRST_PERSON:{
+                            Minecraft.getInstance().options.setCameraType(CameraType.FIRST_PERSON);
+                            break;
+                        }
+                        case THIRD_PERSON:{
+                            Minecraft.getInstance().options.setCameraType(CameraType.THIRD_PERSON_BACK);
+                            break;
+                        }
+                        case THIRD_PERSON_INVERTED:{
+                            Minecraft.getInstance().options.setCameraType(CameraType.THIRD_PERSON_FRONT);
+                            break;
+                        }
+                    }
+                    cameraModeRequest = null;
+                }
+
+                //Update camera state, since this can change depending on tick if we check during renders.
+                CameraType cameraModeEnum = Minecraft.getInstance().options.getCameraType();
+                switch(cameraModeEnum) {
+                    case FIRST_PERSON:{
+                        actualCameraMode = CameraMode.FIRST_PERSON;
+                        break;
+                    }
+                    case THIRD_PERSON_BACK:{
+                        actualCameraMode = CameraMode.THIRD_PERSON;
+                        break;
+                    }
+                    case THIRD_PERSON_FRONT:{
+                        actualCameraMode = CameraMode.THIRD_PERSON_INVERTED;
+                        break;
                     }
                 }
             }
         }
     }
 }
+

--- a/mcinterfaceforge1122/src/main/java/mcinterface1122/InterfaceClient.java
+++ b/mcinterfaceforge1122/src/main/java/mcinterface1122/InterfaceClient.java
@@ -1,172 +1,94 @@
-package mcinterface1211;
+package mcinterface1122;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 
 import minecrafttransportsimulator.baseclasses.Point3D;
-import minecrafttransportsimulator.entities.instances.EntityFluidTank;
 import minecrafttransportsimulator.guis.components.AGUIBase;
 import minecrafttransportsimulator.guis.instances.GUIPackMissing;
-import minecrafttransportsimulator.items.components.AItemPack;
-import minecrafttransportsimulator.items.components.AItemSubTyped;
-import minecrafttransportsimulator.jsondefs.AJSONMultiModelProvider;
-import minecrafttransportsimulator.mcinterface.AWrapperWorld;
 import minecrafttransportsimulator.mcinterface.IInterfaceClient;
 import minecrafttransportsimulator.mcinterface.IWrapperItemStack;
 import minecrafttransportsimulator.mcinterface.IWrapperPlayer;
 import minecrafttransportsimulator.mcinterface.InterfaceManager;
 import minecrafttransportsimulator.packloading.PackParser;
-import minecrafttransportsimulator.rendering.AModelParser;
-import minecrafttransportsimulator.rendering.RenderText;
 import minecrafttransportsimulator.systems.CameraSystem.CameraMode;
 import minecrafttransportsimulator.systems.ConfigSystem;
 import minecrafttransportsimulator.systems.ControlSystem;
-import minecrafttransportsimulator.systems.LanguageSystem;
-import net.minecraft.ChatFormatting;
-import net.minecraft.client.CameraType;
+import net.minecraft.block.SoundType;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.screens.ChatScreen;
-import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.Style;
-import net.minecraft.network.chat.TextColor;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.TooltipFlag;
-import net.minecraft.world.level.block.SoundType;
-import net.minecraft.world.level.material.Fluid;
-import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.neoforge.fluids.FluidStack;
-import net.neoforged.fml.common.EventBusSubscriber;
-import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.ActiveRenderInfo;
+import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
+import net.minecraftforge.fml.relauncher.Side;
 
-@EventBusSubscriber(modid = InterfaceLoader.MODID, value = Dist.CLIENT)
+@EventBusSubscriber(Side.CLIENT)
 public class InterfaceClient implements IInterfaceClient {
     private static CameraMode actualCameraMode;
     private static CameraMode cameraModeRequest;
     private static int ticksToCullingWarning = 200;
-
-    /**Model preloading state — spreads parsing across ticks to avoid a single big freeze.*/
-    private static List<String> modelsToPreload = null;
-    private static int preloadIndex = 0;
-    private static final int MODELS_PER_TICK = 3;
-
-    /**
-     * Initiates model preloading by collecting all unique model locations from loaded packs.
-     * Actual parsing is spread across subsequent client ticks via tickModelPreload().
-     */
-    private static void initModelPreload() {
-        if (modelsToPreload != null) {
-            return; //Already started or finished.
-        }
-        Set<String> uniqueLocations = new HashSet<>();
-        for (AItemPack<?> item : PackParser.getAllPackItems()) {
-            if (item instanceof AItemSubTyped) {
-                AItemSubTyped<?> subTypedItem = (AItemSubTyped<?>) item;
-                if (subTypedItem.definition instanceof AJSONMultiModelProvider) {
-                    try {
-                        String modelLocation = ((AJSONMultiModelProvider) subTypedItem.definition).getModelLocation(subTypedItem.subDefinition);
-                        if (modelLocation != null) {
-                            uniqueLocations.add(modelLocation);
-                        }
-                    } catch (Exception ignored) {}
-                }
-            }
-        }
-        modelsToPreload = new ArrayList<>(uniqueLocations);
-        preloadIndex = 0;
-        InterfaceManager.coreInterface.logError("MTS model preload: " + modelsToPreload.size() + " unique models queued.");
-    }
-
-    /**
-     * Parses a few models per tick on the main thread.  This avoids thread-safety issues
-     * with AModelParser's HashMap cache while spreading the work to prevent a single big stutter.
-     */
-    private static void tickModelPreload() {
-        if (modelsToPreload == null || preloadIndex >= modelsToPreload.size()) {
-            return;
-        }
-        int end = Math.min(preloadIndex + MODELS_PER_TICK, modelsToPreload.size());
-        for (int i = preloadIndex; i < end; i++) {
-            try {
-                AModelParser.parseModel(modelsToPreload.get(i), true);
-            } catch (Exception ignored) {
-                //Skip models that fail — they'll error at render time.
-            }
-        }
-        preloadIndex = end;
-        if (preloadIndex >= modelsToPreload.size()) {
-            InterfaceManager.coreInterface.logError("MTS model preload complete: " + modelsToPreload.size() + " models cached.");
-        }
-    }
+    private static BuilderEntityRenderForwarder activeFollower;
+    private static int ticksSincePlayerJoin;
 
     @Override
     public boolean isGamePaused() {
-        return Minecraft.getInstance().isPaused();
+        return Minecraft.getMinecraft().isGamePaused();
     }
 
     @Override
     public String getLanguageName() {
-        if (Minecraft.getInstance().getLanguageManager() != null) {
-            return Minecraft.getInstance().getLanguageManager().getSelected();
-        } else {
-            return "en_us";
-        }
+        return Minecraft.getMinecraft().gameSettings.language;
     }
 
     @Override
     public List<String> getAllLanguages() {
         List<String> list = new ArrayList<>();
-        Minecraft.getInstance().getLanguageManager().getLanguages().forEach((languageCode, languageInfo) -> list.add(languageCode));
+        Minecraft.getMinecraft().getLanguageManager().getLanguages().forEach(language -> list.add(language.getLanguageCode()));
         return list;
     }
 
     @Override
     public String getFluidName(String fluidID, String fluidMod) {
-        for (Entry<ResourceKey<Fluid>, Fluid> fluidEntry : BuiltInRegistries.FLUID.entrySet()) {
-            ResourceLocation fluidLocation = fluidEntry.getKey().location();
-            if ((fluidMod.equals(EntityFluidTank.WILDCARD_FLUID_MOD) || fluidLocation.getNamespace().equals(fluidMod)) && fluidLocation.getPath().equals(fluidID)) {
-                return fluidEntry.getValue().getFluidType().getDescription().getString();
-            }
-        }
-        return "INVALID";
+        Fluid fluid = FluidRegistry.getFluid(fluidID);
+        return fluid != null ? new FluidStack(fluid, 1).getLocalizedName() : "INVALID";
     }
 
     @Override
     public Map<String, String> getAllFluidNames() {
         Map<String, String> fluidIDsToNames = new HashMap<>();
-        for (Fluid fluid : BuiltInRegistries.FLUID) {
-            fluidIDsToNames.put(BuiltInRegistries.FLUID.getKey(fluid).getPath(), new FluidStack(fluid, 1).getDisplayName().getString());
+        for (String fluidID : FluidRegistry.getRegisteredFluids().keySet()) {
+            fluidIDsToNames.put(fluidID, new FluidStack(FluidRegistry.getFluid(fluidID), 1).getLocalizedName());
         }
         return fluidIDsToNames;
     }
 
     @Override
     public boolean isChatOpen() {
-        return Minecraft.getInstance().screen instanceof ChatScreen;
+        return Minecraft.getMinecraft().ingameGUI.getChatGUI().getChatOpen();
     }
 
     @Override
     public boolean isGUIOpen() {
-        return Minecraft.getInstance().screen != null;
+        return Minecraft.getMinecraft().currentScreen != null;
     }
 
     @Override
-    public boolean isGUIHidden() {
-        return Minecraft.getInstance().options.hideGui;
-    }
-
     public void displayOverlayMessage(String message) {
-        Minecraft.getInstance().gui.setOverlayMessage(Component.literal(message), false);
+        Minecraft.getMinecraft().ingameGUI.setOverlayMessage(message, false);
     }
 
     @Override
@@ -181,63 +103,66 @@ public class InterfaceClient implements IInterfaceClient {
 
     @Override
     public int getCameraDefaultZoom() {
-        return 0;
+        return 4;
     }
 
     @Override
     public long getPackedDisplaySize() {
-        return (((long) Minecraft.getInstance().getWindow().getGuiScaledWidth()) << Integer.SIZE) | (Minecraft.getInstance().getWindow().getGuiScaledHeight() & 0xffffffffL);
+        ScaledResolution screenResolution = new ScaledResolution(Minecraft.getMinecraft());
+        return (((long) screenResolution.getScaledWidth()) << Integer.SIZE) | (screenResolution.getScaledHeight() & 0xffffffffL);
     }
-
-    @Override
-    public float getFOV() {
-        return Minecraft.getInstance().options.fov().get();
-    }
-
-    @Override
-    public void setFOV(float setting) {
-        ((Ifov) ((Object) Minecraft.getInstance().options.fov())).setManual((int) setting);
-    }
-
-    //Linked to the OptionInstanceMixin so we can implement a common interface.
-    public static interface Ifov {
-        public void setManual(Integer value);
-    };
 
     @Override
     public float getMouseSensitivity() {
-        return Minecraft.getInstance().options.sensitivity().get().floatValue();
+        return Minecraft.getMinecraft().gameSettings.mouseSensitivity;
     }
 
     @Override
     public void setMouseSensitivity(float setting) {
-        Minecraft.getInstance().options.sensitivity().set((double) setting);
+        Minecraft.getMinecraft().gameSettings.mouseSensitivity = setting;
+    }
+
+    @Override
+    public float getFOV() {
+        return Minecraft.getMinecraft().gameSettings.fovSetting;
+    }
+
+    @Override
+    public void setFOV(float setting) {
+        Minecraft.getMinecraft().gameSettings.fovSetting = setting;
+    }
+
+    @Override
+    public boolean isGUIHidden() {
+        return Minecraft.getMinecraft().gameSettings.hideGUI;
     }
 
     @Override
     public void closeGUI() {
-        Minecraft.getInstance().setScreen(null);
+        Minecraft.getMinecraft().displayGuiScreen(null);
     }
 
     @Override
     public void setActiveGUI(AGUIBase gui) {
-        Minecraft.getInstance().setScreen(new BuilderGUI(gui));
+        FMLCommonHandler.instance().showGuiScreen(new BuilderGUI(gui));
     }
 
     @Override
     public WrapperWorld getClientWorld() {
-        return WrapperWorld.getWrapperFor(Minecraft.getInstance().level);
+        return WrapperWorld.getWrapperFor(Minecraft.getMinecraft().world);
     }
 
     @Override
     public WrapperPlayer getClientPlayer() {
-        return WrapperPlayer.getWrapperFor(Minecraft.getInstance().player);
+        EntityPlayer player = Minecraft.getMinecraft().player;
+        return WrapperPlayer.getWrapperFor(player);
     }
 
     @Override
     public Point3D getCameraPosition() {
-        Vec3 cameraOffset = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
-        mutablePosition.set(cameraOffset.x, cameraOffset.y, cameraOffset.z);
+        EntityPlayer player = Minecraft.getMinecraft().player;
+        Vec3d cameraOffset = ActiveRenderInfo.getCameraPosition();
+        mutablePosition.set(player.posX + cameraOffset.x, player.posY + cameraOffset.y, player.posZ + cameraOffset.z);
         return mutablePosition;
     }
 
@@ -245,52 +170,19 @@ public class InterfaceClient implements IInterfaceClient {
 
     @Override
     public void playBlockBreakSound(Point3D position) {
-        BlockPos pos = BlockPos.containing(position.x, position.y, position.z);
-        if (!Minecraft.getInstance().level.isEmptyBlock(pos)) {
-            SoundType soundType = Minecraft.getInstance().level.getBlockState(pos).getBlock().getSoundType(Minecraft.getInstance().level.getBlockState(pos), Minecraft.getInstance().player.level(), pos, null);
-            Minecraft.getInstance().level.playSound(Minecraft.getInstance().player, pos, soundType.getBreakSound(), SoundSource.BLOCKS, soundType.getVolume(), soundType.getPitch());
+        BlockPos pos = new BlockPos(position.x, position.y, position.z);
+        if (!Minecraft.getMinecraft().world.isAirBlock(pos)) {
+            SoundType soundType = Minecraft.getMinecraft().world.getBlockState(pos).getBlock().getSoundType(Minecraft.getMinecraft().world.getBlockState(pos), Minecraft.getMinecraft().player.world, pos, null);
+            Minecraft.getMinecraft().world.playSound(Minecraft.getMinecraft().player, pos, soundType.getBreakSound(), SoundCategory.BLOCKS, soundType.getVolume(), soundType.getPitch());
         }
     }
 
     @Override
     public List<String> getTooltipLines(IWrapperItemStack stack) {
-        List<String> tooltipText = new ArrayList<>();
-        List<Component> tooltipLines = ((WrapperItemStack) stack).stack.getTooltipLines(Item.TooltipContext.EMPTY, Minecraft.getInstance().player, Minecraft.getInstance().options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL);
+        List<String> tooltipText = ((WrapperItemStack) stack).stack.getTooltip(Minecraft.getMinecraft().player, Minecraft.getMinecraft().gameSettings.advancedItemTooltips ? ITooltipFlag.TooltipFlags.ADVANCED : ITooltipFlag.TooltipFlags.NORMAL);
         //Add grey formatting text to non-first line tooltips.
-        for (int i = 0; i < tooltipLines.size(); ++i) {
-            Component component = tooltipLines.get(i);
-            Style style = component.getStyle();
-            String stringToAdd = "";
-            if (style.isBold()) {
-                stringToAdd += RenderText.FORMATTING_CHAR + RenderText.BOLD_FORMATTING_CHAR;
-            }
-            if (style.isItalic()) {
-                stringToAdd += RenderText.FORMATTING_CHAR + RenderText.ITALIC_FORMATTING_CHAR;
-            }
-            if (style.isUnderlined()) {
-                stringToAdd += RenderText.FORMATTING_CHAR + RenderText.UNDERLINE_FORMATTING_CHAR;
-            }
-            if (style.isStrikethrough()) {
-                stringToAdd += RenderText.FORMATTING_CHAR + RenderText.STRIKETHROUGH_FORMATTING_CHAR;
-            }
-            if (style.isObfuscated()) {
-                stringToAdd += RenderText.FORMATTING_CHAR + RenderText.RANDOM_FORMATTING_CHAR;
-            }
-            if (style.getColor() != null) {
-                ChatFormatting legacyColor = null;
-                for (ChatFormatting format : ChatFormatting.values()) {
-                    if (format.isColor()) {
-                        if (style.getColor().equals(TextColor.fromLegacyFormat(format))) {
-                            legacyColor = format;
-                            break;
-                        }
-                    }
-                }
-                if (legacyColor != null) {
-                    stringToAdd += RenderText.FORMATTING_CHAR + Integer.toHexString(legacyColor.ordinal());
-                }
-            }
-            tooltipText.add(stringToAdd + tooltipLines.get(i).getString());
+        for (int i = 1; i < tooltipText.size(); ++i) {
+            tooltipText.set(i, TextFormatting.GRAY + tooltipText.get(i));
         }
         return tooltipText;
     }
@@ -301,86 +193,95 @@ public class InterfaceClient implements IInterfaceClient {
      * not being called on clients.
      */
     @SubscribeEvent
-    public static void onIVClientTickPre(net.neoforged.neoforge.client.event.ClientTickEvent.Pre event) {
+    public static void onIVClientTick(TickEvent.ClientTickEvent event) {
         IWrapperPlayer player = InterfaceManager.clientInterface.getClientPlayer();
         if (!InterfaceManager.clientInterface.isGamePaused() && player != null) {
-            AWrapperWorld world = InterfaceManager.clientInterface.getClientWorld();
+            WrapperWorld world = WrapperWorld.getWrapperFor(Minecraft.getMinecraft().world);
             if (world != null) {
-                //Kick off / continue model preloading across ticks.
-                initModelPreload();
-                tickModelPreload();
-                if (!player.isSpectator()) {
-                    //Handle controls.  This has to happen prior to vehicle updates to ensure click handling is based on current position of the player.
-                    ControlSystem.controlGlobal(player);
-                    if (((WrapperPlayer) player).player.tickCount % 100 == 0) {
-                        if (!InterfaceManager.clientInterface.isGUIOpen() && !PackParser.arePacksPresent()) {
-                            new GUIPackMissing();
+                if (event.phase.equals(Phase.START)) {
+                    if (!player.isSpectator()) {
+                        //Handle controls.  This has to happen prior to vehicle updates to ensure click handling is based on current position of the player.
+                        ControlSystem.controlGlobal(player);
+                        if (((WrapperPlayer) player).player.ticksExisted % 100 == 0) {
+                            if (!InterfaceManager.clientInterface.isGUIOpen() && !PackParser.arePacksPresent()) {
+                                new GUIPackMissing();
+                            }
                         }
                     }
-                }
 
-                //Need to update world brightness since sky darken isn't calculated normally on clients.
-                ((WrapperWorld) world).world.updateSkyBrightness();
+                    world.tickAll(true);
 
-                world.tickAll(true);
+                    //Complain about compats at 10 second mark.
+                    if (ConfigSystem.settings.general.performModCompatFunctions.value) {
+                        if (ticksToCullingWarning > 0) {
+                            if (--ticksToCullingWarning == 0) {
+                                //Nothing to complain about here!
+                            }
+                        }
+                    }
+
+                    //Check follower.
+                    if (activeFollower != null) {
+                        //Follower exists, check if world is the same and it is actually updating.
+                        //We check basic states, and then the watchdog bit that gets reset every tick.
+                        //This way if we're in the world, but not valid we will know.
+                        EntityPlayer mcPlayer = ((WrapperPlayer) player).player;
+                        if (activeFollower.world != mcPlayer.world || activeFollower.playerFollowing != mcPlayer || mcPlayer.isDead || activeFollower.isDead || activeFollower.idleTickCounter == 20) {
+                            //Follower is not linked.  Remove it and re-create in code below.
+                            activeFollower.setDead();
+                            activeFollower = null;
+                            ticksSincePlayerJoin = 0;
+                        } else {
+                            ++activeFollower.idleTickCounter;
+                        }
+                    } else {
+                        //Follower does not exist, check if player has been present for 3 seconds and spawn it.
+                        if (++ticksSincePlayerJoin == 60) {
+                            activeFollower = new BuilderEntityRenderForwarder(((WrapperPlayer) player).player);
+                            activeFollower.loadedFromSavedNBT = true;
+                            world.world.spawnEntity(activeFollower);
+                        }
+                    }
+                } else {
+                    world.tickAll(false);
                     
-                //Complain about Entity Culling mod at 10 second mark.
-                if(ConfigSystem.settings.general.performModCompatFunctions.value && InterfaceManager.coreInterface.isModPresent("entityculling")) {
-                    if(ticksToCullingWarning > 0) {
-                        if(--ticksToCullingWarning == 0) {
-                            player.displayChatMessage(LanguageSystem.SYSTEM_DEBUG, "IV HAS DETECTED THAT ENTITY CULLING MOD IS PRESENT.  THIS MOD CULLS ALL IV VEHICLES UNLESS \"mts:builder_existing\", \"mts:builder_rendering\", AND \"mts:builder_seat\" ARE ADDED TO THE WHITELIST.");
-                        }
+                    //Handle camera requests.
+                    if(cameraModeRequest != null) {
+                    	switch(cameraModeRequest) {
+	                    	case FIRST_PERSON:{
+	                    		Minecraft.getMinecraft().gameSettings.thirdPersonView = 0;
+	                    		break;
+	                    	}
+	                    	case THIRD_PERSON:{
+	                    		Minecraft.getMinecraft().gameSettings.thirdPersonView = 1;
+	                    		break;
+	                    	}
+	                    	case THIRD_PERSON_INVERTED:{
+	                    		Minecraft.getMinecraft().gameSettings.thirdPersonView = 2;
+	                    		break;
+	                    	}
+                    	}
+                    	cameraModeRequest = null;
                     }
-                }
-            }
-        }
-    }
 
-    @SubscribeEvent
-    public static void onIVClientTickPost(net.neoforged.neoforge.client.event.ClientTickEvent.Post event) {
-        IWrapperPlayer player = InterfaceManager.clientInterface.getClientPlayer();
-        if (!InterfaceManager.clientInterface.isGamePaused() && player != null) {
-            AWrapperWorld world = InterfaceManager.clientInterface.getClientWorld();
-            if (world != null) {
-                world.tickAll(false);
-                    
-                //Handle camera requests.
-                if(cameraModeRequest != null) {
-                    switch(cameraModeRequest) {
-                        case FIRST_PERSON:{
-                            Minecraft.getInstance().options.setCameraType(CameraType.FIRST_PERSON);
-                            break;
-                        }
-                        case THIRD_PERSON:{
-                            Minecraft.getInstance().options.setCameraType(CameraType.THIRD_PERSON_BACK);
-                            break;
-                        }
-                        case THIRD_PERSON_INVERTED:{
-                            Minecraft.getInstance().options.setCameraType(CameraType.THIRD_PERSON_FRONT);
-                            break;
-                        }
-                    }
-                    cameraModeRequest = null;
-                }
-
-                //Update camera state, since this can change depending on tick if we check during renders.
-                CameraType cameraModeEnum = Minecraft.getInstance().options.getCameraType();
-                switch(cameraModeEnum) {
-                    case FIRST_PERSON:{
-                        actualCameraMode = CameraMode.FIRST_PERSON;
-                        break;
-                    }
-                    case THIRD_PERSON_BACK:{
-                        actualCameraMode = CameraMode.THIRD_PERSON;
-                        break;
-                    }
-                    case THIRD_PERSON_FRONT:{
-                        actualCameraMode = CameraMode.THIRD_PERSON_INVERTED;
-                        break;
+                    //Update camera state, since this can change depending on tick if we check during renders.
+                    int cameraModeInt = Minecraft.getMinecraft().gameSettings.thirdPersonView;
+                    switch(cameraModeInt) {
+                    	case(0):{
+                    		actualCameraMode = CameraMode.FIRST_PERSON;
+                    		break;
+                    	}
+                    	case(1):{
+                    		actualCameraMode = CameraMode.THIRD_PERSON;
+                    		break;
+                    	}
+                    	case(2):{
+                    		actualCameraMode = CameraMode.THIRD_PERSON_INVERTED;
+                    		break;
+                    	}
                     }
                 }
             }
         }
     }
 }
-

--- a/mcinterfaceforge1165/src/main/java/mcinterface1165/InterfaceClient.java
+++ b/mcinterfaceforge1165/src/main/java/mcinterface1165/InterfaceClient.java
@@ -149,6 +149,11 @@ public class InterfaceClient implements IInterfaceClient {
     }
 
     @Override
+    public boolean isGUIHidden() {
+        return Minecraft.getInstance().options.hideGui;
+    }
+
+    @Override
     public void closeGUI() {
         Minecraft.getInstance().setScreen(null);
     }

--- a/mcinterfaceforge1182/src/main/java/mcinterface1182/InterfaceClient.java
+++ b/mcinterfaceforge1182/src/main/java/mcinterface1182/InterfaceClient.java
@@ -149,6 +149,11 @@ public class InterfaceClient implements IInterfaceClient {
     }
 
     @Override
+    public boolean isGUIHidden() {
+        return Minecraft.getInstance().options.hideGui;
+    }
+
+    @Override
     public void closeGUI() {
         Minecraft.getInstance().setScreen(null);
     }

--- a/mcinterfaceforge1192/src/main/java/mcinterface1192/InterfaceClient.java
+++ b/mcinterfaceforge1192/src/main/java/mcinterface1192/InterfaceClient.java
@@ -152,6 +152,11 @@ public class InterfaceClient implements IInterfaceClient {
     }
 
     @Override
+    public boolean isGUIHidden() {
+        return Minecraft.getInstance().options.hideGui;
+    }
+
+    @Override
     public void closeGUI() {
         Minecraft.getInstance().setScreen(null);
     }

--- a/mcinterfaceforge1201/src/main/java/mcinterface1201/InterfaceClient.java
+++ b/mcinterfaceforge1201/src/main/java/mcinterface1201/InterfaceClient.java
@@ -152,6 +152,11 @@ public class InterfaceClient implements IInterfaceClient {
     }
 
     @Override
+    public boolean isGUIHidden() {
+        return Minecraft.getInstance().options.hideGui;
+    }
+
+    @Override
     public void closeGUI() {
         Minecraft.getInstance().setScreen(null);
     }

--- a/mcinterfaceneoforge1211/src/main/java/mcinterface1211/InterfaceClient.java
+++ b/mcinterfaceneoforge1211/src/main/java/mcinterface1211/InterfaceClient.java
@@ -160,6 +160,11 @@ public class InterfaceClient implements IInterfaceClient {
         return Minecraft.getInstance().screen != null;
     }
 
+    @Override
+    public boolean isGUIHidden() {
+        return Minecraft.getInstance().options.hideGui;
+    }
+
     public void displayOverlayMessage(String message) {
         Minecraft.getInstance().gui.setOverlayMessage(Component.literal(message), false);
     }


### PR DESCRIPTION
PR adds two pack-authoring/runtime features aimed at cockpit/interactable UX without changing existing behavior:

1. `guiTextObjects`
2. box-specific collision hover variables


New Function: `guiTextObjects`
-  `rendering.guiTextObjects` section alongside existing `textObjects`.
- This is intended for screen-space text prompts tied to vehicles/parts, similar to existing HUD/overlay prompts, rather than world-space text rendered on the model.
- The implementation reuses the existing `JSONText` structure where possible, so pack authors can use the same text settings they already know:
  - `defaultText`
  - `fontName`
  - `scale`
  - `wrapWidth`
  - `renderPosition`
  - `color`
  - `variableName` / `variableFormat`
- Added GUI-specific support fields on `JSONText`:
  - `animations`
  - `fadeInTime`
  - `fadeOutTime`
- Rendering is client-side only and is done through the overlay GUI path, not the entity/world model renderer.
- Coordinates are screen-space, relative to screen center:
  - `+X` = right
  - `+Y` = down
  - `scale 1.0` = normal GUI font size
- Visibility/fading is animation-driven:
  - if animations resolve true, the text fades in
  - if they resolve false, the text fades out
  - default fade time is 7 ticks if not specified
- Variable-backed GUI text uses the same formatting path as normal text objects, so existing variable formatting behavior stays consistent.
- Added alpha-aware text rendering so GUI prompts can fade rather than pop.


All of this is used for fancy on-screen text, like instruments but for funny shti like this:

https://github.com/user-attachments/assets/aedd173a-5566-4916-a0ce-e36c3c54d05f



Visibility / player scoping
- `guiTextObjects` are rendered only on the local client overlay.
- Hover-driven prompts such as `player_cursor_hovered` and `collision_*_player_cursor_hovered` are therefore local to the player actually hovering the control.
- Added a GUI-hidden check so these prompts do not render when the player hides the HUD/GUI with F1.



## Aklo added box xsepcific collision hover variable
- Existing behavior remains unchanged:
  - `collision_<group>_player_cursor_hovered` still becomes true when *any* box in that collision group is hovered.
- Added optional per-box hover support:
  - `collision_<group>_<box>_player_cursor_hovered`
- `<box>` is 1-based and follows the order of the `collisions` array inside that collision group.
- The overlay hover tracking now sets/clears both:
  - the existing group-wide variable
  - the new exact-box variable
- Moving between boxes in the same group now correctly clears the previous box-specific variable and sets the new one.

This basically allows pack authors to attach prompts/animations to a specific collision box without breaking existing group-based setups. Or having to create an entirely different collision group for one hover text.

 also added `isGUIHidden()` support across all maintained interface modules so the F1/hidden-GUI behavior works on every supported version


- Existing `textObjects` behavior is unchanged.
- Existing `collision_<group>_...` variables are unchanged.
- The new features are additive:
  - packs that do not use `guiTextObjects` are unaffected
  - packs that do not use `collision_<group>_<box>_...` are unaffected

