### PR TITLE
Fixed issue that stopped mccore from compiling

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/mcinterface/IInterfaceClient.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/mcinterface/IInterfaceClient.java
@@ -58,6 +58,11 @@ public interface IInterfaceClient {
     boolean isGUIOpen();
 
     /**
+     * Returns true if the HUD/GUI is hidden by the client.
+     */
+    boolean isGUIHidden();
+
+    /**
      * Displays a short-lived overlay message above the hotbar.
      */
     void displayOverlayMessage(String message);


### PR DESCRIPTION
Immediate compile failure in GUIOverlay.java (line 264), because InterfaceManager.clientInterface is typed as IInterfaceClient, and IInterfaceClient did not declare isGUIHidden().