### PR TITLE
Added "defaultZoom" to "Motorised"

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityB_Existing.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityB_Existing.java
@@ -115,7 +115,7 @@ public abstract class AEntityB_Existing extends AEntityA_Base {
             this.position = data.getPoint3d("position");
             this.orientation = new RotationMatrix().setToAngles(data.getPoint3d("angles"));
             this.motion = data.getPoint3d("motion");
-            this.zoomLevel = data.hasKey("zoomLevel") ? Math.max(0, data.getInteger("zoomLevel")) : 0;
+            this.zoomLevel = data.getInteger("zoomLevel");
             this.cameraIndex = data.getInteger("cameraIndex");
             this.radioData = data.getData("radio");
         } else {

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityB_Existing.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityB_Existing.java
@@ -115,7 +115,7 @@ public abstract class AEntityB_Existing extends AEntityA_Base {
             this.position = data.getPoint3d("position");
             this.orientation = new RotationMatrix().setToAngles(data.getPoint3d("angles"));
             this.motion = data.getPoint3d("motion");
-            this.zoomLevel = data.getInteger("zoomLevel");
+            this.zoomLevel = data.hasKey("zoomLevel") ? Math.max(0, data.getInteger("zoomLevel")) : 0;
             this.cameraIndex = data.getInteger("cameraIndex");
             this.radioData = data.getData("radio");
         } else {
@@ -521,9 +521,8 @@ public abstract class AEntityB_Existing extends AEntityA_Base {
         if (radio != null) {
             data.setData("radio", radio.save(InterfaceManager.coreInterface.getNewNBTWrapper()));
         }
-        if (!cameras.isEmpty()) {
-            data.setInteger("zoomLevel", zoomLevel);
-            data.setInteger("cameraIndex", cameraIndex);
+        data.setInteger("zoomLevel", zoomLevel);
+        data.setInteger("cameraIndex", cameraIndex);
         }
         return data;
     }

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartSeat.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartSeat.java
@@ -47,6 +47,9 @@ public final class PartSeat extends APart {
 
     public PartSeat(AEntityF_Multipart<?> entityOn, IWrapperPlayer placingPlayer, JSONPartDefinition placementDefinition, ItemPartSeat item, IWrapperNBT data) {
         super(entityOn, placingPlayer, placementDefinition, item, data);
+        if (vehicleOn != null && (data == null || !data.hasKey("zoomLevel"))) {
+            this.zoomLevel = Math.max(0, vehicleOn.definition.motorized.defaultZoom);
+        }
         if (data != null) {
             this.activeGunItem = PackParser.getItem(data.getString("activeGunPackID"), data.getString("activeGunSystemName"), data.getString("activeGunSubName"));
         }

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartSeat.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartSeat.java
@@ -48,7 +48,7 @@ public final class PartSeat extends APart {
     public PartSeat(AEntityF_Multipart<?> entityOn, IWrapperPlayer placingPlayer, JSONPartDefinition placementDefinition, ItemPartSeat item, IWrapperNBT data) {
         super(entityOn, placingPlayer, placementDefinition, item, data);
         if (vehicleOn != null && (data == null || !data.hasKey("zoomLevel"))) {
-            this.zoomLevel = Math.max(0, vehicleOn.definition.motorized.defaultZoom);
+            this.zoomLevel = vehicleOn.definition.motorized.defaultZoom;
         }
         if (data != null) {
             this.activeGunItem = PackParser.getItem(data.getString("activeGunPackID"), data.getString("activeGunSystemName"), data.getString("activeGunSubName"));

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONVehicle.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONVehicle.java
@@ -30,6 +30,9 @@ public class JSONVehicle extends AJSONPartProvider {
 
         @JSONDescription("If set to true, this vehicle will attempt to get and use the light states of any vehicle that is towing it. Useful for trailers where you want the lights to come on with the vehicle, but not towed cars where you want them to stay off.")
         public boolean isTrailer;
+        
+        @JSONDescription("Sets the default third-person zoom level when this vehicle is spawned.  0 is the closest possible camera position, 1 is one step out, 2 is two steps out, and so on.  This only affects the starting zoom level; players can still zoom in or out normally after entering the vehicle.")
+        public int defaultZoom;
 
         @JSONDescription("Set this to true if you want the vehicle to have thrust vectoring.  False means only yaw-vectoring will occur for things like engine out situations.")
         public boolean hasThrustVectoring;


### PR DESCRIPTION
added motorized.defaultZoom in JSONVehicle.java, 
applied that default in PartSeat.java, and changed AEntityB_Existing.java to always save/load zoomLevel so dev-mode imports keep the current zoom instead of resetting it. 
In JSON, "defaultZoom": X goes under motorized, 0 = the closest camera position.
