### PR TITLE
new config_x variables + 1 client config setting + render config tweaks + desc fix

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
@@ -1005,6 +1005,8 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
                 return new ComputedVariable(this, variable, partialTicks -> InterfaceManager.clientInterface.getClientPlayer().getPosition().subtract(position).getAngles(true).z, false);
             case ("config_simplethrottle"):
                 return new ComputedVariable(this, variable, partialTicks -> ConfigSystem.client.controlSettings.simpleThrottle.value ? 1 : 0, false);
+			case ("config_arcade"):
+                return new ComputedVariable(this, variable, partialTicks -> ConfigSystem.client.controlSettings.arcadeMode.value ? 1 : 0, false);
             case ("config_innerwindows"):
                 return new ComputedVariable(this, variable, partialTicks -> ConfigSystem.client.renderingSettings.innerWindows.value ? 1 : 0, false);
             default: {

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
@@ -1005,6 +1005,8 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
                 return new ComputedVariable(this, variable, partialTicks -> InterfaceManager.clientInterface.getClientPlayer().getPosition().subtract(position).getAngles(true).z, false);
             case ("config_simplethrottle"):
                 return new ComputedVariable(this, variable, partialTicks -> ConfigSystem.client.controlSettings.simpleThrottle.value ? 1 : 0, false);
+			case ("config_autostartengines"):
+                return new ComputedVariable(this, variable, partialTicks -> ConfigSystem.client.controlSettings.autostartEng.value ? 1 : 0, false);
 			case ("config_arcade"):
                 return new ComputedVariable(this, variable, partialTicks -> ConfigSystem.client.controlSettings.arcadeMode.value ? 1 : 0, false);
 			case ("config_tutorial"):

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
@@ -1007,6 +1007,8 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
                 return new ComputedVariable(this, variable, partialTicks -> ConfigSystem.client.controlSettings.simpleThrottle.value ? 1 : 0, false);
 			case ("config_arcade"):
                 return new ComputedVariable(this, variable, partialTicks -> ConfigSystem.client.controlSettings.arcadeMode.value ? 1 : 0, false);
+			case ("config_tutorial"):
+                return new ComputedVariable(this, variable, partialTicks -> ConfigSystem.client.controlSettings.showTutorial.value ? 1 : 0, false);
             case ("config_innerwindows"):
                 return new ComputedVariable(this, variable, partialTicks -> ConfigSystem.client.renderingSettings.innerWindows.value ? 1 : 0, false);
             default: {

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONConfigClient.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONConfigClient.java
@@ -23,8 +23,8 @@ public class JSONConfigClient {
         public JSONConfigEntry<Boolean> fullHUD_1P = new JSONConfigEntry<>(false, "If true, the full-size HUD will render in 1st-person rather than the half-size HUD.");
         public JSONConfigEntry<Boolean> fullHUD_3P = new JSONConfigEntry<>(false, "If true, the full-size HUD will render in 3rd-person rather than the half-size HUD.");
 
-        public JSONConfigEntry<Boolean> transpHUD_1P = new JSONConfigEntry<>(false, "If true, the background textures for the HUD will not be rendered in 1st-person.");
-        public JSONConfigEntry<Boolean> transpHUD_3P = new JSONConfigEntry<>(false, "If true, the background textures for the HUD will not be rendered in 1st-person.");
+        public JSONConfigEntry<Boolean> transpHUD_1P = new JSONConfigEntry<>(true, "If true, the background textures for the HUD will not be rendered in 1st-person.");
+        public JSONConfigEntry<Boolean> transpHUD_3P = new JSONConfigEntry<>(true, "If true, the background textures for the HUD will not be rendered in 3rd-person.");
 
         public JSONConfigEntry<Boolean> renderWindows = new JSONConfigEntry<>(true, "Should the glass on windows be rendered on vehicles?");
         public JSONConfigEntry<Boolean> innerWindows = new JSONConfigEntry<>(false, "Should the glass on windows be rendered on the inside of the vehicle?  Note: if renderWindows is false, this config has no effect.");

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONConfigClient.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONConfigClient.java
@@ -56,6 +56,7 @@ public class JSONConfigClient {
         public JSONConfigEntry<Boolean> heliAutoLevel = new JSONConfigEntry<>(false, "If true, helicopters will automatically return to level flight when you let off the control stick.  However, this will prevent them from doing loops.  The realistic value for this config is false, but the one that's more player-freindly is true.");
         public JSONConfigEntry<Boolean> mouseYoke = new JSONConfigEntry<>(false, "If true, aircraft pitch and roll are controlled by an invisible on-screen mouse yoke.  Cursor center is neutral; window edges are full input.");
         public JSONConfigEntry<Boolean> arcadeMode = new JSONConfigEntry<>(false, "If true, arcade-style flight and aiming will be enabled. This allows the mouse cursor to control aircraft/helicopter steering systems and enables the gun aiming crosshair.");
+        public JSONConfigEntry<Boolean> showTutorial = new JSONConfigEntry<>(true, "If true, tutorial and onboarding overlays may be shown.  Set this to false to hide those prompts.");
 
         public JSONConfigEntry<Boolean> classicJystk = new JSONConfigEntry<>(false, "If true, the classic controller code will be used.  Note: THIS CODE MAY CRASH MOBILE DEVICES!  Also note that switching will probably mess up your keybinds.  Only do this if you are having issues with a joystick or controller not being recognized.  After changing this setting, reboot the game to make it take effect.");
 


### PR DESCRIPTION
Added variables:
`config_arcade` returns 1 when its active, like config_simplethrottle
`config_tutorial` returns 1 when its active
`config_autostartengines` returns 1 when its active

Added **client config**:
showTutorial - a simple 1 and 0 switch, used to trigger tutorial texts client side.
Goal is accessibility, along with the newly addd arcade mode. We are making IV optionally easier to understand for new users to hopefully grow its audienece and breathe new life in the low morale of the PA circle 

Transparent panel rendering option is now true by default, as many people complained about it being obstructive.
Also found a typo where 3p setting description was saying for 1st person despite being for 3rd.

https://github.com/user-attachments/assets/fa79af67-e0ee-4569-ba99-1ccebd0a103c

