### PR TITLE
Made simpleThrottle capable of shifting manual transmissions

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/AEntityVehicleE_Powered.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/AEntityVehicleE_Powered.java
@@ -47,6 +47,7 @@ public abstract class AEntityVehicleE_Powered extends AEntityVehicleD_Moving {
 	public final ComputedVariable reverseThrustVar;
 	public final ComputedVariable electricUsageVar;
 	public final ComputedVariable batteryCapacityVar;
+    public final ComputedVariable isSimpleThrottleVar;
     public static final double MAX_THROTTLE = 1.0D;
 
     //Internal states.
@@ -101,6 +102,7 @@ public abstract class AEntityVehicleE_Powered extends AEntityVehicleD_Moving {
     	addVariable(this.reverseThrustVar = new ComputedVariable(this, "reverser", data));
     	addVariable(this.electricUsageVar = new ComputedVariable(this, "electric_usage", data));
     	addVariable(this.batteryCapacityVar = new ComputedVariable(this, "batteryCapacity", data));
+    	addVariable(this.isSimpleThrottleVar = new ComputedVariable(this, "simplethrottle", data));
     }
 
     @Override

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
@@ -47,7 +47,7 @@ public class PartEngine extends APart {
     //Internal variables.
     private boolean autoStarterEngaged;
     private int starterLevel;
-    private int shiftCooldown;
+    public int shiftCooldown;
     private double lowestWheelVelocity;
     private double desiredWheelVelocity;
     private double engineAxialVelocity;
@@ -80,10 +80,10 @@ public class PartEngine extends APart {
 
     private final ComputedVariable maxRPMVar;
     private final ComputedVariable maxSafeRPMVar;
-    private final ComputedVariable revLimitRPMVar;
+    public final ComputedVariable revLimitRPMVar;
     private final ComputedVariable revLimitBounceVar;
     private final ComputedVariable revResistanceVar;
-    private final ComputedVariable idleRPMVar;
+    public final ComputedVariable idleRPMVar;
     private final ComputedVariable startRPMVar;
     private final ComputedVariable stallRPMVar;
     private final ComputedVariable starterPowerVar;
@@ -441,8 +441,10 @@ public class PartEngine extends APart {
                     } else {
                         --shiftCooldown;
                     }
+                } else if (!isAutomaticVar.isActive && currentGearVar.currentValue != 0 && shiftCooldown > 0) { //Handle shift cooldown logic anyways, for anyone still checking shift speed.
+                    --shiftCooldown;
                 }
-
+                
                 //Add extra hours, and possibly explode the engine, if it's too hot.
                 if (temp > OVERHEAT_TEMP_1 && !vehicleOn.isCreative) {
                     hoursVar.adjustBy(0.001 * (temp - OVERHEAT_TEMP_1) * getTotalWearFactor(), false);

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/PartEngine.java
@@ -47,7 +47,7 @@ public class PartEngine extends APart {
     //Internal variables.
     private boolean autoStarterEngaged;
     private int starterLevel;
-    public int shiftCooldown;
+    private int shiftCooldown;
     private double lowestWheelVelocity;
     private double desiredWheelVelocity;
     private double engineAxialVelocity;
@@ -80,10 +80,10 @@ public class PartEngine extends APart {
 
     private final ComputedVariable maxRPMVar;
     private final ComputedVariable maxSafeRPMVar;
-    public final ComputedVariable revLimitRPMVar;
+    private final ComputedVariable revLimitRPMVar;
     private final ComputedVariable revLimitBounceVar;
     private final ComputedVariable revResistanceVar;
-    public final ComputedVariable idleRPMVar;
+    private final ComputedVariable idleRPMVar;
     private final ComputedVariable startRPMVar;
     private final ComputedVariable stallRPMVar;
     private final ComputedVariable starterPowerVar;
@@ -416,7 +416,7 @@ public class PartEngine extends APart {
                 }
 
                 //Do automatic transmission functions if needed.
-                if (isAutomaticVar.isActive && !world.isClient() && currentGearVar.currentValue != 0) {
+                if ((isAutomaticVar.isActive || vehicleOn.isSimpleThrottleVar.isActive) && !world.isClient() && currentGearVar.currentValue != 0) {
                     if (shiftCooldown == 0) {
                         if (currentGearVar.currentValue > 0 ? currentGearVar.currentValue < forwardsGears : -currentGearVar.currentValue < reverseGears) {
                             //Can shift up, try to do so.
@@ -441,10 +441,8 @@ public class PartEngine extends APart {
                     } else {
                         --shiftCooldown;
                     }
-                } else if (!isAutomaticVar.isActive && currentGearVar.currentValue != 0 && shiftCooldown > 0) { //Handle shift cooldown logic anyways, for anyone still checking shift speed.
-                    --shiftCooldown;
                 }
-                
+
                 //Add extra hours, and possibly explode the engine, if it's too hot.
                 if (temp > OVERHEAT_TEMP_1 && !vehicleOn.isCreative) {
                     hoursVar.adjustBy(0.001 * (temp - OVERHEAT_TEMP_1) * getTotalWearFactor(), false);

--- a/mccore/src/main/java/minecrafttransportsimulator/systems/ControlSystem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/systems/ControlSystem.java
@@ -735,9 +735,9 @@ public final class ControlSystem {
                     if (!ConfigSystem.client.controlSettings.useShifter.value) {
                         powered.engines.forEach(engine -> {
                             //If we don't have velocity, and we have the appropriate control, shift.
-                            if ((brakeValue > EntityVehicleF_Physics.MAX_BRAKE / 4F && engine.currentGearVar.currentValue >= 0 && powered.axialVelocity < 0.01F) || (powered.axialVelocity > 0.01F && engine.shiftCooldown == 0 && engine.currentGearVar.currentValue >= 2 && engine.rpm <= (engine.idleRPMVar.currentValue * 1.1875F))) {
+                            if (brakeValue > EntityVehicleF_Physics.MAX_BRAKE / 4F && engine.currentGearVar.currentValue >= 0 && powered.axialVelocity < 0.01F) {
                                 InterfaceManager.packetInterface.sendToServer(new PacketEntityVariableSet(engine.shiftDownVar, 1));
-                            } else if ((throttleValue > EntityVehicleF_Physics.MAX_THROTTLE / 4F && engine.currentGearVar.currentValue <= 0 && powered.axialVelocity < 0.01F) || (powered.axialVelocity > 0.01F && engine.shiftCooldown == 0 && engine.currentGearVar.currentValue >= 1 && engine.rpm >= (engine.revLimitRPMVar.currentValue * 0.875F))) {
+                            } else if (throttleValue > EntityVehicleF_Physics.MAX_THROTTLE / 4F && engine.currentGearVar.currentValue <= 0 && powered.axialVelocity < 0.01F) {
                                 InterfaceManager.packetInterface.sendToServer(new PacketEntityVariableSet(engine.shiftUpVar, 1));
                             }
                         });
@@ -839,7 +839,7 @@ public final class ControlSystem {
             } else {
                 if (ControlsKeyboard.CAR_SHIFT_U.isPressed()) {
                     powered.engines.forEach(engine -> {
-                        if (engine.isAutomaticVar.isActive) {
+                        if (engine.isAutomaticVar.isActive || powered.isSimpleThrottleVar.isActive) {
                             if (engine.currentGearVar.currentValue < 0) {
                                 InterfaceManager.packetInterface.sendToServer(new PacketEntityVariableToggle(engine.shiftNeutralVar));
                             } else if (engine.currentGearVar.currentValue == 0) {
@@ -852,7 +852,7 @@ public final class ControlSystem {
                 }
                 if (ControlsKeyboard.CAR_SHIFT_D.isPressed()) {
                     powered.engines.forEach(engine -> {
-                        if (engine.isAutomaticVar.isActive) {
+                        if (engine.isAutomaticVar.isActive || powered.isSimpleThrottleVar.isActive) {
                             if (engine.currentGearVar.currentValue > 0) {
                                 InterfaceManager.packetInterface.sendToServer(new PacketEntityVariableToggle(engine.shiftNeutralVar));
                             } else if (engine.currentGearVar.currentValue == 0) {
@@ -864,6 +864,12 @@ public final class ControlSystem {
                     });
                 }
             }
+            //Check if we are simpleThrottle and if so, kindly ask vehicles to treat their manual transmissions as auto transmissions. Also has us send auto-type shift packets when enabled.
+            if (ConfigSystem.client.controlSettings.simpleThrottle.value && !powered.isSimpleThrottleVar.isActive) {
+                InterfaceManager.packetInterface.sendToServer(new PacketEntityVariableSet(powered.isSimpleThrottleVar, 1));
+             } else if (!ConfigSystem.client.controlSettings.simpleThrottle.value && powered.isSimpleThrottleVar.isActive) {
+                InterfaceManager.packetInterface.sendToServer(new PacketEntityVariableSet(powered.isSimpleThrottleVar, 0));
+             }
         }
 
         //Check if horn button is pressed.

--- a/mccore/src/main/java/minecrafttransportsimulator/systems/ControlSystem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/systems/ControlSystem.java
@@ -735,9 +735,9 @@ public final class ControlSystem {
                     if (!ConfigSystem.client.controlSettings.useShifter.value) {
                         powered.engines.forEach(engine -> {
                             //If we don't have velocity, and we have the appropriate control, shift.
-                            if (brakeValue > EntityVehicleF_Physics.MAX_BRAKE / 4F && engine.currentGearVar.currentValue >= 0 && powered.axialVelocity < 0.01F) {
+                            if ((brakeValue > EntityVehicleF_Physics.MAX_BRAKE / 4F && engine.currentGearVar.currentValue >= 0 && powered.axialVelocity < 0.01F) || (powered.axialVelocity > 0.01F && engine.shiftCooldown == 0 && engine.currentGearVar.currentValue >= 2 && engine.rpm <= (engine.idleRPMVar.currentValue * 1.1875F))) {
                                 InterfaceManager.packetInterface.sendToServer(new PacketEntityVariableSet(engine.shiftDownVar, 1));
-                            } else if (throttleValue > EntityVehicleF_Physics.MAX_THROTTLE / 4F && engine.currentGearVar.currentValue <= 0 && powered.axialVelocity < 0.01F) {
+                            } else if ((throttleValue > EntityVehicleF_Physics.MAX_THROTTLE / 4F && engine.currentGearVar.currentValue <= 0 && powered.axialVelocity < 0.01F) || (powered.axialVelocity > 0.01F && engine.shiftCooldown == 0 && engine.currentGearVar.currentValue >= 1 && engine.rpm >= (engine.revLimitRPMVar.currentValue * 0.875F))) {
                                 InterfaceManager.packetInterface.sendToServer(new PacketEntityVariableSet(engine.shiftUpVar, 1));
                             }
                         });


### PR DESCRIPTION
Copilot title: "Enhance gear shifting logic and update shiftCooldown visibility"

simpleThrottle will now try to shift manual engines when they are at 87.5% of their revLimitRPM*
Engines will now always countdown the shiftCooldown, even if they are manual.

Probably messy but I'm a very sad clanker right now. 

<img width="250" height="208" alt="5kAUC0ng" src="https://github.com/user-attachments/assets/af9f4480-1356-4864-bcb9-367c0d057f37" />
