### PR TITLE
Disabled more interaction parameters for builder_rendering

### DIFF
--- a/mcinterfaceforge1122/src/main/java/mcinterface1122/BuilderEntityRenderForwarder.java
+++ b/mcinterfaceforge1122/src/main/java/mcinterface1122/BuilderEntityRenderForwarder.java
@@ -6,6 +6,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.block.material.EnumPushReaction;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.event.RegistryEvent;
@@ -80,6 +81,26 @@ public class BuilderEntityRenderForwarder extends ABuilderEntityBase {
     public EnumPushReaction getPushReaction() {
         //This entity only exists as a render anchor and should not be treated as a physical obstacle.
         return EnumPushReaction.IGNORE;
+    }
+
+    @Override
+    public void setPortal(BlockPos pos) {
+        //This entity only exists as a render anchor and should not trigger portal timers or sounds.
+    }
+
+    @Override
+    public boolean canBePushed() {
+        return false;
+    }
+
+    @Override
+    public boolean isPushedByWater() {
+        return false;
+    }
+
+    @Override
+    public boolean doesEntityNotTriggerPressurePlate() {
+        return true;
     }
 
     /**

--- a/mcinterfaceforge1165/src/main/java/mcinterface1165/BuilderEntityRenderForwarder.java
+++ b/mcinterfaceforge1165/src/main/java/mcinterface1165/BuilderEntityRenderForwarder.java
@@ -5,6 +5,7 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.block.material.PushReaction;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.RegistryObject;
@@ -67,6 +68,31 @@ public class BuilderEntityRenderForwarder extends ABuilderEntityBase {
     public PushReaction getPistonPushReaction() {
         //This entity only exists as a render anchor and should not be treated as a physical obstacle.
         return PushReaction.IGNORE;
+    }
+
+    @Override
+    public void handleInsidePortal(BlockPos pos) {
+        //This entity only exists as a render anchor and should not trigger portal timers or sounds.
+    }
+
+    @Override
+    public boolean canChangeDimensions() {
+        return false;
+    }
+
+    @Override
+    public boolean isPushedByFluid() {
+        return false;
+    }
+
+    @Override
+    public boolean isPushable() {
+        return false;
+    }
+
+    @Override
+    public boolean isIgnoringBlockTriggers() {
+        return true;
     }
 
     @Override

--- a/mcinterfaceforge1165/src/main/java/mcinterface1165/BuilderEntityRenderForwarder.java
+++ b/mcinterfaceforge1165/src/main/java/mcinterface1165/BuilderEntityRenderForwarder.java
@@ -81,6 +81,12 @@ public class BuilderEntityRenderForwarder extends ABuilderEntityBase {
     }
 
     @Override
+    public boolean isSpectator() {
+        //This entity only exists as a render anchor and should be ignored by entity scanners like Mekanism's teleporter.
+        return true;
+    }
+
+    @Override
     public boolean isPushedByFluid() {
         return false;
     }

--- a/mcinterfaceforge1182/src/main/java/mcinterface1182/BuilderEntityRenderForwarder.java
+++ b/mcinterfaceforge1182/src/main/java/mcinterface1182/BuilderEntityRenderForwarder.java
@@ -81,6 +81,12 @@ public class BuilderEntityRenderForwarder extends ABuilderEntityBase {
     }
 
     @Override
+    public boolean isSpectator() {
+        //This entity only exists as a render anchor and should be ignored by entity scanners like Mekanism's teleporter.
+        return true;
+    }
+
+    @Override
     public boolean isPushedByFluid() {
         return false;
     }

--- a/mcinterfaceforge1182/src/main/java/mcinterface1182/BuilderEntityRenderForwarder.java
+++ b/mcinterfaceforge1182/src/main/java/mcinterface1182/BuilderEntityRenderForwarder.java
@@ -1,6 +1,7 @@
 package mcinterface1182;
 
 import minecrafttransportsimulator.baseclasses.Point3D;
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
@@ -67,6 +68,31 @@ public class BuilderEntityRenderForwarder extends ABuilderEntityBase {
     public PushReaction getPistonPushReaction() {
         //This entity only exists as a render anchor and should not be treated as a physical obstacle.
         return PushReaction.IGNORE;
+    }
+
+    @Override
+    public void handleInsidePortal(BlockPos pos) {
+        //This entity only exists as a render anchor and should not trigger portal timers or sounds.
+    }
+
+    @Override
+    public boolean canChangeDimensions() {
+        return false;
+    }
+
+    @Override
+    public boolean isPushedByFluid() {
+        return false;
+    }
+
+    @Override
+    public boolean isPushable() {
+        return false;
+    }
+
+    @Override
+    public boolean isIgnoringBlockTriggers() {
+        return true;
     }
 
     @Override

--- a/mcinterfaceforge1192/src/main/java/mcinterface1192/BuilderEntityRenderForwarder.java
+++ b/mcinterfaceforge1192/src/main/java/mcinterface1192/BuilderEntityRenderForwarder.java
@@ -81,6 +81,12 @@ public class BuilderEntityRenderForwarder extends ABuilderEntityBase {
     }
 
     @Override
+    public boolean isSpectator() {
+        //This entity only exists as a render anchor and should be ignored by entity scanners like Mekanism's teleporter.
+        return true;
+    }
+
+    @Override
     public boolean isPushedByFluid() {
         return false;
     }

--- a/mcinterfaceforge1192/src/main/java/mcinterface1192/BuilderEntityRenderForwarder.java
+++ b/mcinterfaceforge1192/src/main/java/mcinterface1192/BuilderEntityRenderForwarder.java
@@ -1,6 +1,7 @@
 package mcinterface1192;
 
 import minecrafttransportsimulator.baseclasses.Point3D;
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
@@ -67,6 +68,31 @@ public class BuilderEntityRenderForwarder extends ABuilderEntityBase {
     public PushReaction getPistonPushReaction() {
         //This entity only exists as a render anchor and should not be treated as a physical obstacle.
         return PushReaction.IGNORE;
+    }
+
+    @Override
+    public void handleInsidePortal(BlockPos pos) {
+        //This entity only exists as a render anchor and should not trigger portal timers or sounds.
+    }
+
+    @Override
+    public boolean canChangeDimensions() {
+        return false;
+    }
+
+    @Override
+    public boolean isPushedByFluid() {
+        return false;
+    }
+
+    @Override
+    public boolean isPushable() {
+        return false;
+    }
+
+    @Override
+    public boolean isIgnoringBlockTriggers() {
+        return true;
     }
 
     @Override

--- a/mcinterfaceforge1201/src/main/java/mcinterface1201/BuilderEntityRenderForwarder.java
+++ b/mcinterfaceforge1201/src/main/java/mcinterface1201/BuilderEntityRenderForwarder.java
@@ -81,6 +81,12 @@ public class BuilderEntityRenderForwarder extends ABuilderEntityBase {
     }
 
     @Override
+    public boolean isSpectator() {
+        //This entity only exists as a render anchor and should be ignored by entity scanners like Mekanism's teleporter.
+        return true;
+    }
+
+    @Override
     public boolean isPushedByFluid() {
         return false;
     }

--- a/mcinterfaceforge1201/src/main/java/mcinterface1201/BuilderEntityRenderForwarder.java
+++ b/mcinterfaceforge1201/src/main/java/mcinterface1201/BuilderEntityRenderForwarder.java
@@ -1,6 +1,7 @@
 package mcinterface1201;
 
 import minecrafttransportsimulator.baseclasses.Point3D;
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
@@ -67,6 +68,31 @@ public class BuilderEntityRenderForwarder extends ABuilderEntityBase {
     public PushReaction getPistonPushReaction() {
         //This entity only exists as a render anchor and should not be treated as a physical obstacle.
         return PushReaction.IGNORE;
+    }
+
+    @Override
+    public void handleInsidePortal(BlockPos pos) {
+        //This entity only exists as a render anchor and should not trigger portal timers or sounds.
+    }
+
+    @Override
+    public boolean canChangeDimensions() {
+        return false;
+    }
+
+    @Override
+    public boolean isPushedByFluid() {
+        return false;
+    }
+
+    @Override
+    public boolean isPushable() {
+        return false;
+    }
+
+    @Override
+    public boolean isIgnoringBlockTriggers() {
+        return true;
     }
 
     @Override

--- a/mcinterfaceneoforge1211/src/main/java/mcinterface1211/BuilderEntityRenderForwarder.java
+++ b/mcinterfaceneoforge1211/src/main/java/mcinterface1211/BuilderEntityRenderForwarder.java
@@ -80,6 +80,12 @@ public class BuilderEntityRenderForwarder extends ABuilderEntityBase {
     }
 
     @Override
+    public boolean isSpectator() {
+        //This entity only exists as a render anchor and should be ignored by entity scanners like Mekanism's teleporter.
+        return true;
+    }
+
+    @Override
     public boolean isPushedByFluid() {
         return false;
     }

--- a/mcinterfaceneoforge1211/src/main/java/mcinterface1211/BuilderEntityRenderForwarder.java
+++ b/mcinterfaceneoforge1211/src/main/java/mcinterface1211/BuilderEntityRenderForwarder.java
@@ -1,9 +1,11 @@
 package mcinterface1211;
 
 import minecrafttransportsimulator.baseclasses.Point3D;
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.block.Portal;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.PushReaction;
 import net.minecraft.world.phys.Vec3;
@@ -65,6 +67,31 @@ public class BuilderEntityRenderForwarder extends ABuilderEntityBase {
     public PushReaction getPistonPushReaction() {
         //This entity only exists as a render anchor and should not be treated as a physical obstacle.
         return PushReaction.IGNORE;
+    }
+
+    @Override
+    public void setAsInsidePortal(Portal portal, BlockPos pos) {
+        //This entity only exists as a render anchor and should not trigger portal timers or sounds.
+    }
+
+    @Override
+    public boolean canUsePortal(boolean allowPassengers) {
+        return false;
+    }
+
+    @Override
+    public boolean isPushedByFluid() {
+        return false;
+    }
+
+    @Override
+    public boolean isPushable() {
+        return false;
+    }
+
+    @Override
+    public boolean isIgnoringBlockTriggers() {
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Users reported the rendering entity going tiny portals and making portal sounds and such. 
This disables a broad amount of possible interactions.

Mainly focussed on portals, but also includes ignoring fluid flow, pressure plates and being pushed