### PR TITLE
Patched being able to place blocks through IV hotboxes + fixes

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityB_Existing.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityB_Existing.java
@@ -523,7 +523,6 @@ public abstract class AEntityB_Existing extends AEntityA_Base {
         }
         data.setInteger("zoomLevel", zoomLevel);
         data.setInteger("cameraIndex", cameraIndex);
-        }
         return data;
     }
 }

--- a/mccore/src/main/java/minecrafttransportsimulator/systems/ControlSystem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/systems/ControlSystem.java
@@ -35,6 +35,7 @@ import minecrafttransportsimulator.systems.LanguageSystem.LanguageEntry;
  */
 public final class ControlSystem {
     private static final int NULL_COMPONENT = 999;
+    private static final double INTERACTION_DISTANCE = 3.5;
     private static final long DISMOUNT_CONFIRM_WINDOW_MILLIS = 3000L;
     private static boolean joysticksInhibited = false;
     private static IWrapperPlayer clientPlayer;
@@ -109,6 +110,21 @@ public final class ControlSystem {
         mouseYokePosY = Double.NaN;
     }
 
+    /**
+     * Returns true when vanilla use-item handling should be suppressed because the player is
+     * targeting an IV click hitbox.  IV handles these clicks separately in {@link #handleClick},
+     * so allowing vanilla to process the same input may place or use an item on a block behind
+     * the IV entity.
+     */
+    public static boolean shouldSuppressVanillaRightClick(IWrapperPlayer player) {
+        if (player != null && player.getWorld() != null) {
+            Point3D startPosition = player.getEyePosition();
+            Point3D endPosition = player.getLineOfSight(INTERACTION_DISTANCE).add(startPosition);
+            return player.getWorld().getMultipartEntityIntersect(startPosition, endPosition) != null;
+        }
+        return false;
+    }
+
     public static void setMouseYokeEnabled(boolean enabled, boolean displayMessage) {
         ConfigSystem.client.controlSettings.mouseYoke.value = enabled;
         ConfigSystem.saveToDisk();
@@ -179,7 +195,7 @@ public final class ControlSystem {
         }
         if (leftClickDown || rightClickDown) {
             Point3D startPosition = player.getEyePosition();
-            Point3D endPosition = player.getLineOfSight(3.5).add(startPosition);
+            Point3D endPosition = player.getLineOfSight(INTERACTION_DISTANCE).add(startPosition);
 
             interactResult = player.getWorld().getMultipartEntityIntersect(startPosition, endPosition);
             if (interactResult != null) {

--- a/mccore/src/main/java/minecrafttransportsimulator/systems/LanguageSystem.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/systems/LanguageSystem.java
@@ -378,6 +378,8 @@ public class LanguageSystem {
     public static final LanguageEntry INTERACT_VEHICLE_JUMPERPACK = new LanguageEntry("interact.vehicle.jumperpack", "Charged vehicle battery to maximum.");
     public static final LanguageEntry INTERACT_VEHICLE_NOFUEL = new LanguageEntry("interact.vehicle.nofuel", "There is no fuel in this vehicle.  The engine cannot start!");
     public static final LanguageEntry INTERACT_VEHICLE_DISMOUNTCONFIRM = new LanguageEntry("interact.vehicle.dismountconfirm", "Press Shift again to dismount");
+    public static final LanguageEntry INTERACT_MOUSEYOKE_ENABLED = new LanguageEntry("interact.mouseyoke.enabled", "Mouse Yoke enabled");
+    public static final LanguageEntry INTERACT_MOUSEYOKE_DISABLED = new LanguageEntry("interact.mouseyoke.disabled", "Mouse Yoke disabled");
     public static final LanguageEntry INTERACT_ARCADEMODE_ENABLED = new LanguageEntry("interact.arcademode.enabled", "Arcade Mode enabled");
     public static final LanguageEntry INTERACT_ARCADEMODE_DISABLED = new LanguageEntry("interact.arcademode.disabled", "Arcade Mode disabled");
     

--- a/mcinterfaceforge1122/src/main/java/mcinterface1122/InterfaceInput.java
+++ b/mcinterfaceforge1122/src/main/java/mcinterface1122/InterfaceInput.java
@@ -27,8 +27,10 @@ import net.java.games.input.Controller;
 import net.java.games.input.ControllerEnvironment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.util.EnumActionResult;
 import net.minecraftforge.client.event.InputUpdateEvent;
 import net.minecraftforge.client.event.MouseEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -351,6 +353,14 @@ public class InterfaceInput implements IInterfaceInput {
     public static void onIVMovementInput(InputUpdateEvent event) {
         if (InterfaceManager.clientInterface != null && ControlSystem.shouldSuppressDismount(InterfaceManager.clientInterface.getClientPlayer(), event.getMovementInput().sneak)) {
             event.getMovementInput().sneak = false;
+        }
+    }
+
+    @SubscribeEvent
+    public static void onIVRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
+        if (event.getEntityPlayer().world.isRemote && InterfaceManager.clientInterface != null && ControlSystem.shouldSuppressVanillaRightClick(InterfaceManager.clientInterface.getClientPlayer())) {
+            event.setCancellationResult(EnumActionResult.SUCCESS);
+            event.setCanceled(true);
         }
     }
 

--- a/mcinterfaceforge1165/src/main/java/mcinterface1165/InterfaceInput.java
+++ b/mcinterfaceforge1165/src/main/java/mcinterface1165/InterfaceInput.java
@@ -27,6 +27,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.client.util.InputMappings;
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.InputEvent.ClickInputEvent;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.client.event.InputEvent.KeyInputEvent;
 import net.minecraftforge.client.event.InputUpdateEvent;
@@ -375,6 +376,14 @@ public class InterfaceInput implements IInterfaceInput {
     public static void onIVMovementInput(InputUpdateEvent event) {
         if (InterfaceManager.clientInterface != null && ControlSystem.shouldSuppressDismount(InterfaceManager.clientInterface.getClientPlayer(), event.getMovementInput().shiftKeyDown)) {
             event.getMovementInput().shiftKeyDown = false;
+        }
+    }
+
+    @SubscribeEvent
+    public static void onIVClickInput(ClickInputEvent event) {
+        if (event.isUseItem() && InterfaceManager.clientInterface != null && ControlSystem.shouldSuppressVanillaRightClick(InterfaceManager.clientInterface.getClientPlayer())) {
+            event.setCanceled(true);
+            event.setSwingHand(false);
         }
     }
 

--- a/mcinterfaceforge1182/src/main/java/mcinterface1182/InterfaceInput.java
+++ b/mcinterfaceforge1182/src/main/java/mcinterface1182/InterfaceInput.java
@@ -27,6 +27,7 @@ import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.ClientRegistry;
+import net.minecraftforge.client.event.InputEvent.ClickInputEvent;
 import net.minecraftforge.client.event.InputEvent.KeyInputEvent;
 import net.minecraftforge.client.event.MovementInputUpdateEvent;
 import net.minecraftforge.client.event.ScreenEvent;
@@ -321,6 +322,14 @@ public class InterfaceInput implements IInterfaceInput {
     public static void onIVMovementInput(MovementInputUpdateEvent event) {
         if (InterfaceManager.clientInterface != null && ControlSystem.shouldSuppressDismount(InterfaceManager.clientInterface.getClientPlayer(), event.getInput().shiftKeyDown)) {
             event.getInput().shiftKeyDown = false;
+        }
+    }
+
+    @SubscribeEvent
+    public static void onIVClickInput(ClickInputEvent event) {
+        if (event.isUseItem() && InterfaceManager.clientInterface != null && ControlSystem.shouldSuppressVanillaRightClick(InterfaceManager.clientInterface.getClientPlayer())) {
+            event.setCanceled(true);
+            event.setSwingHand(false);
         }
     }
 

--- a/mcinterfaceforge1192/src/main/java/mcinterface1192/InterfaceInput.java
+++ b/mcinterfaceforge1192/src/main/java/mcinterface1192/InterfaceInput.java
@@ -327,6 +327,14 @@ public class InterfaceInput implements IInterfaceInput {
         }
     }
 
+    @SubscribeEvent
+    public static void onIVInteractionKeyMapping(InputEvent.InteractionKeyMappingTriggered event) {
+        if (event.isUseItem() && InterfaceManager.clientInterface != null && ControlSystem.shouldSuppressVanillaRightClick(InterfaceManager.clientInterface.getClientPlayer())) {
+            event.setCanceled(true);
+            event.setSwingHand(false);
+        }
+    }
+
     /**
      * Opens the config screen when the config key is pressed.
      * Also init the joystick system if we haven't already.

--- a/mcinterfaceforge1201/src/main/java/mcinterface1201/InterfaceInput.java
+++ b/mcinterfaceforge1201/src/main/java/mcinterface1201/InterfaceInput.java
@@ -327,6 +327,14 @@ public class InterfaceInput implements IInterfaceInput {
         }
     }
 
+    @SubscribeEvent
+    public static void onIVInteractionKeyMapping(InputEvent.InteractionKeyMappingTriggered event) {
+        if (event.isUseItem() && InterfaceManager.clientInterface != null && ControlSystem.shouldSuppressVanillaRightClick(InterfaceManager.clientInterface.getClientPlayer())) {
+            event.setCanceled(true);
+            event.setSwingHand(false);
+        }
+    }
+
     /**
      * Opens the config screen when the config key is pressed.
      * Also init the joystick system if we haven't already.

--- a/mcinterfaceneoforge1211/src/main/java/mcinterface1211/InterfaceInput.java
+++ b/mcinterfaceneoforge1211/src/main/java/mcinterface1211/InterfaceInput.java
@@ -327,6 +327,14 @@ public class InterfaceInput implements IInterfaceInput {
         }
     }
 
+    @SubscribeEvent
+    public static void onIVInteractionKeyMapping(InputEvent.InteractionKeyMappingTriggered event) {
+        if (event.isUseItem() && InterfaceManager.clientInterface != null && ControlSystem.shouldSuppressVanillaRightClick(InterfaceManager.clientInterface.getClientPlayer())) {
+            event.setCanceled(true);
+            event.setSwingHand(false);
+        }
+    }
+
     /**
      * Opens the config screen when the config key is pressed.
      * Also init the joystick system if we haven't already.


### PR DESCRIPTION
RMB on a clickable IV hitbox now consumes Minecraft’s vanilla use action, preventing blocks from being placed behind crates, vehicles, or parts while IV still processes the interaction normally.
This PR fixes this.

**Additional fixes:**
- removed stray closing brace at the end of the entity save method
- ControlSystem references two mouse-yoke language constants that are absent, ("mouseyoke enabled/disabled"), readded the texts back after they have been previously replaced with arcade