### PR TITLE
Made GUI Text Objects support images / textures

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityD_Definable.java
@@ -176,6 +176,7 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
 
     public static final String REPAIRED_NAME = "repaired";
     private static final int DEFAULT_GUI_TEXT_FADE_TICKS = 7;
+    private static final int DEFAULT_GUI_TEXTURE_DELAY_TICKS = 20;
 
     /**
      * Constructor for synced entities
@@ -1113,6 +1114,43 @@ public abstract class AEntityD_Definable<JSONDefinition extends AJSONMultiModelP
      */
     public String getGUITextValue(JSONText textDef, float partialTicks) {
         return formatTextValue(textDef, getCurrentTextValue(textDef), partialTicks);
+    }
+
+    /**
+     * Returns the texture currently selected for the passed-in GUI text definition.
+     * Texture timing is based on entity ticks so all render frames within a tick use the same image.
+     */
+    public String getGUITextureName(JSONText textDef) {
+        if (textDef.textureNames == null || textDef.textureNames.isEmpty()) {
+            return null;
+        } else if (textDef.textureNames.size() == 1) {
+            return textDef.textureNames.get(0);
+        }
+
+        long totalCycleTime = 0;
+        for (int textureIndex = 0; textureIndex < textDef.textureNames.size(); ++textureIndex) {
+            totalCycleTime += getGUITextureDelay(textDef, textureIndex);
+        }
+
+        long timeInCycle = ticksExisted % totalCycleTime;
+        for (int textureIndex = 0; textureIndex < textDef.textureNames.size(); ++textureIndex) {
+            int textureDelay = getGUITextureDelay(textDef, textureIndex);
+            if (timeInCycle < textureDelay) {
+                return textDef.textureNames.get(textureIndex);
+            }
+            timeInCycle -= textureDelay;
+        }
+        return textDef.textureNames.get(0);
+    }
+
+    private static int getGUITextureDelay(JSONText textDef, int textureIndex) {
+        if (textDef.textureDelays != null && !textDef.textureDelays.isEmpty()) {
+            int customDelay = textDef.textureDelays.get(textureIndex % textDef.textureDelays.size());
+            if (customDelay > 0) {
+                return customDelay;
+            }
+        }
+        return DEFAULT_GUI_TEXTURE_DELAY_TICKS;
     }
 
     /**

--- a/mccore/src/main/java/minecrafttransportsimulator/guis/instances/GUIOverlay.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/guis/instances/GUIOverlay.java
@@ -324,13 +324,21 @@ public class GUIOverlay extends AGUIBase {
                     continue;
                 }
 
-                String textValue = entity.getGUITextValue(textDef, partialTicks);
-                if (textValue == null || textValue.isEmpty()) {
-                    continue;
-                }
-
                 //Each tracked entity gets a small Z slice so multiple prompts can overlap without fighting.
-                RenderText.drawGUIText(textValue, entity, textDef, screenWidth, screenHeight, 325 + entityLayer * 5D, alpha);
+                double zOffset = 325 + entityLayer * 5D;
+                if (textDef.textureNames != null && !textDef.textureNames.isEmpty()) {
+                    String textureName = entity.getGUITextureName(textDef);
+                    if (textureName == null || textureName.isEmpty()) {
+                        continue;
+                    }
+                    RenderText.drawGUITexture(textureName, textDef, screenWidth, screenHeight, zOffset, alpha);
+                } else {
+                    String textValue = entity.getGUITextValue(textDef, partialTicks);
+                    if (textValue == null || textValue.isEmpty()) {
+                        continue;
+                    }
+                    RenderText.drawGUIText(textValue, entity, textDef, screenWidth, screenHeight, zOffset, alpha);
+                }
                 shouldKeepTracking = true;
             }
 

--- a/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONText.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/jsondefs/JSONText.java
@@ -10,14 +10,14 @@ import minecrafttransportsimulator.packloading.JSONParser.JSONRequired;
 
 public class JSONText {
     @JSONRequired
-    @JSONDescription("An entry of x, y, and z coordinates that define the center point of where the text should render.  Text may be left or right aligned by specifying the proper parameter.")
+    @JSONDescription("An entry of x, y, and z coordinates that define the center point of where the text or GUI texture should render.  Text may be left or right aligned by specifying the proper parameter.")
     public Point3D pos;
 
-    @JSONDescription("An entry of x, y, and z rotations that tell MTS how to rotate this text.  By default all text faces +z, on the model.")
+    @JSONDescription("An entry of x, y, and z rotations that tell MTS how to rotate this text or GUI texture.  By default all text and textures face +z.")
     public RotationMatrix rot;
 
     @JSONRequired
-    @JSONDescription("The scale of the text.  1.0 will render text about 1/2 block high, as 1 text character pixel equates to one block texture pixel, and text is 8-pixels high.")
+    @JSONDescription("The scale of the text or GUI texture.  1.0 will render text about 1/2 block high, as 1 text character pixel equates to one block texture pixel, and text is 8-pixels high.  GUI textures use a 16 by 16 pixel base size before this scale is applied.")
     public float scale;
 
     @JSONDescription("The name for this text field.  If two text fields share a name, then they both will be combined in the text GUI into one entry, and changing the text in the GUI will affect both of them.  Useful for license plates and route signs.\nNote: if this object is part of text-based rendering system, this defines which variable is displayed.")
@@ -41,15 +41,15 @@ public class JSONText {
     @JSONDescription("An optional folder of a font to use for this field.  If included, this text will be rendered with this font rather than the default font.  Format is [packID:fontname].  Fonts are then named: assets/packID/textures/fonts/unicode_page_xx.png, where xx corresponds with the default font you are replacing.")
     public String fontName;
 
-    @JSONRequired
-    @JSONDescription("The default text to display.  This is what the field will have when the model is first placed down, and will persist until a player changes it.  Required, but may be blank.")
+    @JSONRequired(alternativeField = "textureNames")
+    @JSONDescription("The default text to display.  This is what the field will have when the model is first placed down, and will persist until a player changes it.  Required for text objects, but may be blank.  May be omitted for guiTextObjects that define textureNames.")
     public String defaultText;
 
     @JSONDescription("The max number of characters this entry can have.  Required for editable world text, but optional for guiTextObjects and variable-driven text.")
     public int maxLength;
 
-    @JSONRequired
-    @JSONDescription("A hexadecimal color code.  This tells MTS what color this text should be.")
+    @JSONRequired(alternativeField = "textureNames")
+    @JSONDescription("A hexadecimal color code.  This tells MTS what color this text should be.  May be omitted for guiTextObjects that define textureNames.")
     public ColorRGB color;
 
     @JSONDescription("If set, then this text will get its color from the definition section's secondColor parameter, if one exists for the specified index.")
@@ -70,12 +70,18 @@ public class JSONText {
     @JSONDescription("If true, this text will be auto-scaled to fit inside the wrapWidth rather than actually wrapping to another line.  Has no affect unless you specify a wrapWidth!")
     public boolean autoScale;
 
-    @JSONDescription("Optional animation list for guiTextObjects.  These are normally visibility checks that decide when the text should be shown on-screen.")
+    @JSONDescription("Optional list of textures that makes a guiTextObject render an image instead of text.  Texture locations use the same [packID:path/to/texture.png] format as particle textures.  One texture remains static.  Multiple textures cycle in list order every 20 ticks unless textureDelays is defined.")
+    public List<String> textureNames;
+
+    @JSONDescription("Optional per-texture display times, in ticks, for animated guiTextObjects.  Values correspond to textureNames by index and repeat if this list is shorter.  Missing or non-positive values use the default of 20 ticks.")
+    public List<Integer> textureDelays;
+
+    @JSONDescription("Optional animation list for guiTextObjects.  These are normally visibility checks that decide when the text or texture should be shown on-screen.")
     public List<JSONAnimationDefinition> animations;
 
-    @JSONDescription("Fade-in time for guiTextObjects, in ticks.  If not set, a default of 7 ticks is used.")
+    @JSONDescription("Fade-in time for guiTextObjects, in ticks.  This applies to both text and textures.  If not set, a default of 7 ticks is used.")
     public int fadeInTime;
 
-    @JSONDescription("Fade-out time for guiTextObjects, in ticks.  If not set, a default of 7 ticks is used.")
+    @JSONDescription("Fade-out time for guiTextObjects, in ticks.  This applies to both text and textures.  If not set, a default of 7 ticks is used.")
     public int fadeOutTime;
 }

--- a/mccore/src/main/java/minecrafttransportsimulator/packloading/JSONParser.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/packloading/JSONParser.java
@@ -726,6 +726,12 @@ public class JSONParser {
          * field with one of the dependentValues in a sub-class.
          */
         String subField() default "";
+
+        /**
+         * Optional alternative field that may be supplied in place of this field.  If the alternative is a collection,
+         * it must contain at least one entry to count as present.
+         */
+        String alternativeField() default "";
     }
 
     @Retention(RetentionPolicy.RUNTIME)
@@ -802,6 +808,21 @@ public class JSONParser {
 
             if (testObj == null) {
                 JSONRequired annotation = field.getAnnotation(JSONRequired.class);
+
+                //If an alternative field is defined and present, this field does not need to be supplied.
+                String alternativeVarName = annotation.alternativeField();
+                if (!alternativeVarName.isEmpty()) {
+                    Object alternativeObj = null;
+                    try {
+                        alternativeObj = objectOn.getClass().getField(alternativeVarName).get(objectOn);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                    if (alternativeObj != null && (!(alternativeObj instanceof Collection) || !((Collection<?>) alternativeObj).isEmpty())) {
+                        return null;
+                    }
+                }
+
                 //If we need another field, get it to check.
                 String dependentVarName = annotation.dependentField();
                 if (!dependentVarName.isEmpty()) {

--- a/mccore/src/main/java/minecrafttransportsimulator/rendering/RenderText.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/rendering/RenderText.java
@@ -37,6 +37,16 @@ public class RenderText {
 
     private static final Map<String, FontData> fontDatas = new HashMap<>();
     private static final TransformationMatrix transformHelper = new TransformationMatrix();
+    private static final int GUI_TEXTURE_BASE_SIZE = 16;
+    private static final RenderableData guiTextureRenderable;
+
+    static {
+        RenderableVertices guiTextureVertices = RenderableVertices.createSprite(1, null, null);
+        guiTextureVertices.setSpriteProperties(0, -GUI_TEXTURE_BASE_SIZE / 2, GUI_TEXTURE_BASE_SIZE / 2, GUI_TEXTURE_BASE_SIZE, GUI_TEXTURE_BASE_SIZE, 0, 0, 1, 1);
+        guiTextureRenderable = new RenderableData(guiTextureVertices);
+        guiTextureRenderable.setLightMode(LightingMode.IGNORE_ALL_LIGHTING);
+        guiTextureRenderable.setTransucentOverride();
+    }
 
     /**
      * Draws the specified text.  This is designed for general draws where text is defined in-code, but still may
@@ -101,6 +111,27 @@ public class RenderText {
             transformHelper.applyTranslation(screenWidth / 2D, -screenHeight / 2D, zOffset);
             transformHelper.applyTranslation(definition.pos.x, -definition.pos.y, definition.pos.z);
             getFontData(definition.fontName).renderText(text, transformHelper, definition.rot, TextAlignment.values()[definition.renderPosition], definition.scale, definition.autoScale, definition.wrapWidth, true, color, true, entity.worldLightValue, true, alpha);
+        }
+    }
+
+    /**
+     * Renders a texture from a JSON text definition directly on the player's screen.
+     * The texture is centered on pos and starts at 16 by 16 screen pixels before scale is applied.
+     */
+    public static void drawGUITexture(String texture, JSONText definition, int screenWidth, int screenHeight, double zOffset, float alpha) {
+        if (texture != null && !texture.isEmpty()) {
+            transformHelper.resetTransforms();
+            transformHelper.applyTranslation(screenWidth / 2D, -screenHeight / 2D, zOffset);
+            transformHelper.applyTranslation(definition.pos.x, -definition.pos.y, definition.pos.z);
+            if (definition.rot != null) {
+                transformHelper.applyRotation(definition.rot);
+            }
+            transformHelper.applyScaling(definition.scale, definition.scale, definition.scale);
+
+            guiTextureRenderable.setTexture(texture);
+            guiTextureRenderable.setAlpha(alpha);
+            guiTextureRenderable.transform.set(transformHelper);
+            guiTextureRenderable.render();
         }
     }
 


### PR DESCRIPTION

For GUI Text elements:
- textureNames renders images instead of text.
- Multiple textures defined with textureNames cycle every 20 ticks by default.
- textureDelays sets frame speed, like particles

Usecase for stuff like visual feedback (animated key-presses, animated plane information stuffs, press here, this does that etc)


https://github.com/user-attachments/assets/d9192280-7c22-4a89-9e7d-df81197c5ef9

