### PR TITLE
Fixed bullet hits on entities

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityF_Multipart.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityF_Multipart.java
@@ -366,10 +366,10 @@ public abstract class AEntityF_Multipart<JSONDefinition extends AJSONPartProvide
                     if (bullet.armorPenetrated > penetrationPotential) {
                         //Bullet hit too much armor.
                         if (world.isClient()) {
-                            InterfaceManager.packetInterface.sendToServer(new PacketEntityBulletHitGeneric(bullet.gun, bullet.bulletNumber, hitEntry.position, hitEntry.side, HitType.ARMOR));
+                            InterfaceManager.packetInterface.sendToServer(new PacketEntityBulletHitGeneric(bullet.gun, bullet.bulletNumber, hitEntry.position, bullet.orientation, hitEntry.side, HitType.ARMOR));
                             bullet.waitingOnActionPacket = true;
                         } else {
-                            EntityBullet.performGenericHitLogic(bullet.gun, bullet.bulletNumber, hitEntry.position, hitEntry.side, HitType.ARMOR);
+                            EntityBullet.performGenericHitLogic(bullet.gun, bullet.bulletNumber, hitEntry.position, bullet.orientation, hitEntry.side, HitType.ARMOR);
                         }
                         bullet.displayDebugMessage("HIT TOO MUCH ARMOR.  MAX PEN: " + (int) penetrationPotential);
                         return EntityBullet.HitType.ARMOR;
@@ -404,14 +404,14 @@ public abstract class AEntityF_Multipart<JSONDefinition extends AJSONPartProvide
                     if (world.isClient()) {
                         InterfaceManager.packetInterface.sendToServer(new PacketEntityBulletHitEntity(bullet.gun, hitEntity, damage));
                         if (removeAfterDamage) {
-                            InterfaceManager.packetInterface.sendToServer(new PacketEntityBulletHitGeneric(bullet.gun, bullet.bulletNumber, hitEntry.position, hitEntry.side, HitType.VEHICLE));
+                            InterfaceManager.packetInterface.sendToServer(new PacketEntityBulletHitGeneric(bullet.gun, bullet.bulletNumber, hitEntry.position, bullet.orientation, hitEntry.side, HitType.VEHICLE));
                             bullet.waitingOnActionPacket = true;
                             return EntityBullet.HitType.VEHICLE;
                         }
                     } else {
                         EntityBullet.performEntityHitLogic(hitEntity, damage);
                         if (removeAfterDamage) {
-                            EntityBullet.performGenericHitLogic(bullet.gun, bullet.bulletNumber, hitEntry.position, hitEntry.side, HitType.VEHICLE);
+                            EntityBullet.performGenericHitLogic(bullet.gun, bullet.bulletNumber, hitEntry.position, bullet.orientation, hitEntry.side, HitType.VEHICLE);
                             return EntityBullet.HitType.VEHICLE;
                         }
                     }

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityBullet.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityBullet.java
@@ -63,7 +63,6 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
     public boolean waitingOnActionPacket;
     private int impactDespawnTimer = -1;
     private Point3D targetPosition;
-    private final Point3D helperPoint = new Point3D();
     public double targetDistance;
     private double distanceTraveled;
     public double armorPenetrated;
@@ -310,6 +309,11 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
                 }
             }
 
+            //Set the angles to match the current motion before collision checks so impact orientation is current.
+            if (!isBomb && (definition.bullet.accelerationDelay == 0 || ticksExisted > definition.bullet.accelerationDelay)) {
+                orientation.setToVector(motion, true);
+            }
+
             //Long-range bullets and those fired by NPCs do checks on server only, all others do so on clients.
             //We only do client checks on the primary client, not all clients.
             if (((definition.bullet.isLongRange || !(gun.lastController instanceof IWrapperPlayer)) ^ world.isClient()) && (!world.isClient() || InterfaceManager.clientInterface.getClientPlayer().getID().equals(gun.lastController.getID()))) {
@@ -322,7 +326,9 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
                 AEntityF_Multipart<?> hitMultipart = null;
                 Collection<BoundingBoxHitResult> hitMultipartBoxes = null;
                 IWrapperEntity hitExternalEntity = null;
+                Point3D hitExternalEntityPosition = null;
                 hitBlock = world.getBlockHit(position, motion);
+                Point3D endPoint = position.copy().add(motion);
                 
                 //Check for collided external entities.
                 List<IWrapperEntity> attackedEntities = world.attackEntities(damage, motion, true);
@@ -330,25 +336,26 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
                     //Check to make sure we don't hit our controller.
                     //This can happen with hand-held guns at speed.
                     if (!entity.equals(gun.lastController)) {
+                        BoundingBox entityBounds = entity.getBounds();
+                        BoundingBoxHitResult entityHit = entityBounds.getIntersection(position, endPoint);
+                        Point3D entityHitPosition = entityHit != null ? entityHit.position : entityBounds.globalCenter.copy();
+
                         //Make sure there's not a block in the way.
-                        if (hitBlock != null && position.isFirstCloserThanSecond(hitBlock.hitPosition, entity.getPosition())) {
+                        if (hitBlock != null && position.isFirstCloserThanSecond(hitBlock.hitPosition, entityHitPosition)) {
                             continue;
                         }
 
                         //Check if already-found entity is closer.
-                        if (hitExternalEntity != null) {
-                            //Need to use helper here since the position object will be re-used on next call to other entity.
-                            helperPoint.set(hitExternalEntity.getPosition());
-                            if (position.isFirstCloserThanSecond(helperPoint, entity.getPosition())) {
-                                continue;
-                            }
+                        if (hitExternalEntityPosition != null && position.isFirstCloserThanSecond(hitExternalEntityPosition, entityHitPosition)) {
+                            continue;
                         }
                         hitExternalEntity = entity;
+                        hitExternalEntityPosition = entityHitPosition;
                     }
                 }
 
-                //If we hit a entity, and we have a block hit, we need to discard the block.
-                //The only way tne entity could be hit is if it was in front of the block, and thus the block shouldn't be hit.
+                //If we hit an entity, and we have a block hit, we need to discard the block.
+                //The only way the entity could be hit is if it was in front of the block, and thus the block shouldn't be hit.
                 if (hitExternalEntity != null) {
                     hitBlock = null;
                 }
@@ -356,7 +363,6 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
                 //Populate multiparts for following functions.
                 //Check for collided internal entities.
                 //This is a bit more involved, as we need to check all possible types and check hitbox distance.
-                Point3D endPoint = position.copy().add(motion);
                 BoundingBox bulletMovementBounds = new BoundingBox(position, endPoint);
                 multiparts.clear();
                 world.populateWithEntitiesInBounds(multiparts, bulletMovementBounds);
@@ -389,7 +395,7 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
                                 }
 
                                 //Can't hit hitboxes behind other entities.
-                                if (hitboxCanBeHit && hitExternalEntity != null && position.isFirstCloserThanSecond(hitExternalEntity.getPosition(), hitResult.position)) {
+                                if (hitboxCanBeHit && hitExternalEntityPosition != null && position.isFirstCloserThanSecond(hitExternalEntityPosition, hitResult.position)) {
                                     hitboxCanBeHit = false;
                                 }
 
@@ -417,11 +423,11 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
                 if (hitExternalEntity != null) {
                     if (world.isClient()) {
                         InterfaceManager.packetInterface.sendToServer(new PacketEntityBulletHitExternalEntity(hitExternalEntity, damage));
-                        InterfaceManager.packetInterface.sendToServer(new PacketEntityBulletHitGeneric(gun, bulletNumber, hitExternalEntity.getPosition(), Axis.getFromVector(motion), HitType.ENTITY));
+                        InterfaceManager.packetInterface.sendToServer(new PacketEntityBulletHitGeneric(gun, bulletNumber, hitExternalEntityPosition, orientation, Axis.getFromVector(motion), HitType.ENTITY));
                         waitingOnActionPacket = true;
                     } else {
                         performExternalEntityHitLogic(hitExternalEntity, damage);
-                        performGenericHitLogic(gun, bulletNumber, hitExternalEntity.getPosition(), Axis.getFromVector(motion), HitType.ENTITY);
+                        performGenericHitLogic(gun, bulletNumber, hitExternalEntityPosition, orientation, Axis.getFromVector(motion), HitType.ENTITY);
                     }
                     displayDebugMessage("HIT MC ENTITY " + hitExternalEntity.getName());
                     return;
@@ -440,10 +446,10 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
                         hitBlock.hitPosition.z -= 0.000001;
                     }
                     if (world.isClient()) {
-                        InterfaceManager.packetInterface.sendToServer(new PacketEntityBulletHitGeneric(gun, bulletNumber, hitBlock.hitPosition, hitBlock.side, HitType.BLOCK));
+                        InterfaceManager.packetInterface.sendToServer(new PacketEntityBulletHitGeneric(gun, bulletNumber, hitBlock.hitPosition, orientation, hitBlock.side, HitType.BLOCK));
                         waitingOnActionPacket = true;
                     } else {
-                        performGenericHitLogic(gun, bulletNumber, hitBlock.hitPosition, hitBlock.side, HitType.BLOCK);
+                        performGenericHitLogic(gun, bulletNumber, hitBlock.hitPosition, orientation, hitBlock.side, HitType.BLOCK);
                     }
                     displayDebugMessage("HIT BLOCK AT " + hitBlock.blockPosition + " WITH ACTUAL POSITION " + hitBlock.hitPosition);
                     return;
@@ -523,10 +529,10 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
                             position.interpolate(targetToHit, (distanceToTarget - definition.bullet.proximityFuze) / definition.bullet.proximityFuze);
                         }
                         if (world.isClient()) {
-                            InterfaceManager.packetInterface.sendToServer(new PacketEntityBulletHitGeneric(gun, bulletNumber, position, Axis.getFromVector(motion), hitType));
+                            InterfaceManager.packetInterface.sendToServer(new PacketEntityBulletHitGeneric(gun, bulletNumber, position, orientation, Axis.getFromVector(motion), hitType));
                             waitingOnActionPacket = true;
                         } else {
-                            performGenericHitLogic(gun, bulletNumber, position, Axis.getFromVector(motion), hitType);
+                            performGenericHitLogic(gun, bulletNumber, position, orientation, Axis.getFromVector(motion), hitType);
                         }
                         return;
                     }
@@ -536,10 +542,10 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
                 if (definition.bullet.airBurstDelay != 0) {
                     if (ticksExisted > definition.bullet.airBurstDelay) {
                         if (world.isClient()) {
-                            InterfaceManager.packetInterface.sendToServer(new PacketEntityBulletHitGeneric(gun, bulletNumber, position, Axis.NONE, HitType.BURST));
+                            InterfaceManager.packetInterface.sendToServer(new PacketEntityBulletHitGeneric(gun, bulletNumber, position, orientation, Axis.NONE, HitType.BURST));
                             waitingOnActionPacket = true;
                         } else {
-                            performGenericHitLogic(gun, bulletNumber, position, Axis.NONE, HitType.BURST);
+                            performGenericHitLogic(gun, bulletNumber, position, orientation, Axis.NONE, HitType.BURST);
                         }
                         displayDebugMessage("BURST");
                         return;
@@ -547,13 +553,8 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
                 }
             }
 
-            //Add our updated motion to the position.
-            //Then set the angles to match the motion.
-            //Doing this last lets us damage on the first update tick.
+            //Add our updated motion to the position last so we can damage on the first update tick.
             position.add(motion);
-            if (!isBomb && (definition.bullet.accelerationDelay == 0 || ticksExisted > definition.bullet.accelerationDelay)) {
-                orientation.setToVector(motion, true);
-            }
 
             //Set gun pos if the gun has requested it by creating it.
             if (relativeGunPos != null) {
@@ -639,12 +640,18 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
     }
 
     public static void performGenericHitLogic(PartGun gun, int bulletNumber, Point3D position, Axis hitSide, HitType hitType) {
+        EntityBullet bullet = gun.world.getBullet(gun.uniqueUUID, bulletNumber);
+        performGenericHitLogic(gun, bulletNumber, position, bullet != null ? bullet.orientation : null, hitSide, hitType);
+    }
+
+    public static void performGenericHitLogic(PartGun gun, int bulletNumber, Point3D position, RotationMatrix orientation, Axis hitSide, HitType hitType) {
         //Query up return packets first.  This ensures that we get to do this generic logic which spawns particles on clients before
         //any block-breaking packets arrive.
-        if (!gun.world.isClient()) {
-            InterfaceManager.packetInterface.sendToAllClients(new PacketEntityBulletHitGeneric(gun, bulletNumber, position, hitSide, hitType));
-        }
         EntityBullet bullet = gun.world.getBullet(gun.uniqueUUID, bulletNumber);
+        RotationMatrix impactOrientation = orientation != null ? orientation : bullet != null ? bullet.orientation : new RotationMatrix();
+        if (!gun.world.isClient()) {
+            InterfaceManager.packetInterface.sendToAllClients(new PacketEntityBulletHitGeneric(gun, bulletNumber, position, impactOrientation, hitSide, hitType));
+        }
 
         //Spawn an explosion if we are an explosive bullet on the server.
         if (!gun.world.isClient() && ConfigSystem.settings.damage.bulletExplosions.value) {
@@ -677,6 +684,9 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
 
         if (bullet != null) {
             bullet.position.set(position);
+            bullet.prevPosition.set(position);
+            bullet.orientation.set(impactOrientation);
+            bullet.prevOrientation.set(impactOrientation);
             bullet.lastHit = hitType;
             bullet.sideHit = hitSide;
             bullet.impactDespawnTimer = bullet.definition.bullet.impactDespawnTime;

--- a/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityBullet.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/instances/EntityBullet.java
@@ -641,16 +641,15 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
 
     public static void performGenericHitLogic(PartGun gun, int bulletNumber, Point3D position, Axis hitSide, HitType hitType) {
         EntityBullet bullet = gun.world.getBullet(gun.uniqueUUID, bulletNumber);
-        performGenericHitLogic(gun, bulletNumber, position, bullet != null ? bullet.orientation : null, hitSide, hitType);
+        performGenericHitLogic(gun, bulletNumber, position, bullet != null ? bullet.orientation : new RotationMatrix(), hitSide, hitType);
     }
 
     public static void performGenericHitLogic(PartGun gun, int bulletNumber, Point3D position, RotationMatrix orientation, Axis hitSide, HitType hitType) {
         //Query up return packets first.  This ensures that we get to do this generic logic which spawns particles on clients before
         //any block-breaking packets arrive.
         EntityBullet bullet = gun.world.getBullet(gun.uniqueUUID, bulletNumber);
-        RotationMatrix impactOrientation = orientation != null ? orientation : bullet != null ? bullet.orientation : new RotationMatrix();
         if (!gun.world.isClient()) {
-            InterfaceManager.packetInterface.sendToAllClients(new PacketEntityBulletHitGeneric(gun, bulletNumber, position, impactOrientation, hitSide, hitType));
+            InterfaceManager.packetInterface.sendToAllClients(new PacketEntityBulletHitGeneric(gun, bulletNumber, position, orientation, hitSide, hitType));
         }
 
         //Spawn an explosion if we are an explosive bullet on the server.
@@ -685,8 +684,8 @@ public class EntityBullet extends AEntityD_Definable<JSONBullet> {
         if (bullet != null) {
             bullet.position.set(position);
             bullet.prevPosition.set(position);
-            bullet.orientation.set(impactOrientation);
-            bullet.prevOrientation.set(impactOrientation);
+            bullet.orientation.set(orientation);
+            bullet.prevOrientation.set(orientation);
             bullet.lastHit = hitType;
             bullet.sideHit = hitSide;
             bullet.impactDespawnTimer = bullet.definition.bullet.impactDespawnTime;

--- a/mccore/src/main/java/minecrafttransportsimulator/packets/instances/PacketEntityBulletHitGeneric.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/packets/instances/PacketEntityBulletHitGeneric.java
@@ -34,7 +34,7 @@ public class PacketEntityBulletHitGeneric extends APacketBase {
         this.gunID = gun.uniqueUUID;
         this.bulletNumber = bulletNumber;
         this.position = position.copy();
-        this.orientationAngles = new RotationMatrix().set(orientation).convertToAngles().copy();
+        this.orientationAngles = orientation.convertToAngles().copy();
         this.hitSide = hitSide;
         this.hitType = hitType;
     }
@@ -46,7 +46,7 @@ public class PacketEntityBulletHitGeneric extends APacketBase {
         this.position = readPoint3dFromBuffer(buf);
         this.hitType = HitType.values()[buf.readByte()];
         this.hitSide = Axis.values()[buf.readByte()];
-        this.orientationAngles = buf.readableBytes() >= 3 * Double.BYTES ? readPoint3dFromBuffer(buf) : null;
+        this.orientationAngles = readPoint3dFromBuffer(buf);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class PacketEntityBulletHitGeneric extends APacketBase {
 
     @Override
     public void handle(AWrapperWorld world) {
-        RotationMatrix orientation = orientationAngles != null ? new RotationMatrix().setToAngles(orientationAngles) : null;
+        RotationMatrix orientation = new RotationMatrix().setToAngles(orientationAngles);
         EntityBullet.performGenericHitLogic(world.getBulletGun(gunID), bulletNumber, position, orientation, hitSide, hitType);
     }
 

--- a/mccore/src/main/java/minecrafttransportsimulator/packets/instances/PacketEntityBulletHitGeneric.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/packets/instances/PacketEntityBulletHitGeneric.java
@@ -25,10 +25,6 @@ public class PacketEntityBulletHitGeneric extends APacketBase {
     private final Axis hitSide;
     private final HitType hitType;
 
-    public PacketEntityBulletHitGeneric(PartGun gun, int bulletNumber, Point3D position, Axis hitSide, HitType hitType) {
-        this(gun, bulletNumber, position, getBulletOrientation(gun, bulletNumber), hitSide, hitType);
-    }
-
     public PacketEntityBulletHitGeneric(PartGun gun, int bulletNumber, Point3D position, RotationMatrix orientation, Axis hitSide, HitType hitType) {
         super(null);
         this.gunID = gun.uniqueUUID;
@@ -64,10 +60,5 @@ public class PacketEntityBulletHitGeneric extends APacketBase {
     public void handle(AWrapperWorld world) {
         RotationMatrix orientation = new RotationMatrix().setToAngles(orientationAngles);
         EntityBullet.performGenericHitLogic(world.getBulletGun(gunID), bulletNumber, position, orientation, hitSide, hitType);
-    }
-
-    private static RotationMatrix getBulletOrientation(PartGun gun, int bulletNumber) {
-        EntityBullet bullet = gun.world.getBullet(gun.uniqueUUID, bulletNumber);
-        return bullet != null ? bullet.orientation : new RotationMatrix();
     }
 }

--- a/mccore/src/main/java/minecrafttransportsimulator/packets/instances/PacketEntityBulletHitGeneric.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/packets/instances/PacketEntityBulletHitGeneric.java
@@ -21,7 +21,7 @@ public class PacketEntityBulletHitGeneric extends APacketBase {
     private final UUID gunID;
     private final int bulletNumber;
     private final Point3D position;
-    private final RotationMatrix orientation;
+    private final Point3D orientationAngles;
     private final Axis hitSide;
     private final HitType hitType;
 
@@ -34,7 +34,7 @@ public class PacketEntityBulletHitGeneric extends APacketBase {
         this.gunID = gun.uniqueUUID;
         this.bulletNumber = bulletNumber;
         this.position = position.copy();
-        this.orientation = new RotationMatrix().set(orientation);
+        this.orientationAngles = new RotationMatrix().set(orientation).convertToAngles().copy();
         this.hitSide = hitSide;
         this.hitType = hitType;
     }
@@ -46,7 +46,7 @@ public class PacketEntityBulletHitGeneric extends APacketBase {
         this.position = readPoint3dFromBuffer(buf);
         this.hitType = HitType.values()[buf.readByte()];
         this.hitSide = Axis.values()[buf.readByte()];
-        this.orientation = buf.readableBytes() >= 9 * Double.BYTES ? readRotationMatrixFromBuffer(buf) : null;
+        this.orientationAngles = buf.readableBytes() >= 3 * Double.BYTES ? readPoint3dFromBuffer(buf) : null;
     }
 
     @Override
@@ -57,44 +57,17 @@ public class PacketEntityBulletHitGeneric extends APacketBase {
         writePoint3dToBuffer(position, buf);
         buf.writeByte(hitType.ordinal());
         buf.writeByte(hitSide.ordinal());
-        writeRotationMatrixToBuffer(orientation, buf);
+        writePoint3dToBuffer(orientationAngles, buf);
     }
 
     @Override
     public void handle(AWrapperWorld world) {
+        RotationMatrix orientation = orientationAngles != null ? new RotationMatrix().setToAngles(orientationAngles) : null;
         EntityBullet.performGenericHitLogic(world.getBulletGun(gunID), bulletNumber, position, orientation, hitSide, hitType);
     }
 
     private static RotationMatrix getBulletOrientation(PartGun gun, int bulletNumber) {
         EntityBullet bullet = gun.world.getBullet(gun.uniqueUUID, bulletNumber);
         return bullet != null ? bullet.orientation : new RotationMatrix();
-    }
-
-    private static void writeRotationMatrixToBuffer(RotationMatrix matrix, ByteBuf buf) {
-        buf.writeDouble(matrix.m00);
-        buf.writeDouble(matrix.m01);
-        buf.writeDouble(matrix.m02);
-        buf.writeDouble(matrix.m10);
-        buf.writeDouble(matrix.m11);
-        buf.writeDouble(matrix.m12);
-        buf.writeDouble(matrix.m20);
-        buf.writeDouble(matrix.m21);
-        buf.writeDouble(matrix.m22);
-    }
-
-    private static RotationMatrix readRotationMatrixFromBuffer(ByteBuf buf) {
-        RotationMatrix matrix = new RotationMatrix();
-        matrix.m00 = buf.readDouble();
-        matrix.m01 = buf.readDouble();
-        matrix.m02 = buf.readDouble();
-        matrix.m10 = buf.readDouble();
-        matrix.m11 = buf.readDouble();
-        matrix.m12 = buf.readDouble();
-        matrix.m20 = buf.readDouble();
-        matrix.m21 = buf.readDouble();
-        matrix.m22 = buf.readDouble();
-        matrix.convertToAngles();
-        matrix.updateToAngles();
-        return matrix;
     }
 }

--- a/mccore/src/main/java/minecrafttransportsimulator/packets/instances/PacketEntityBulletHitGeneric.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/packets/instances/PacketEntityBulletHitGeneric.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import io.netty.buffer.ByteBuf;
 import minecrafttransportsimulator.baseclasses.Point3D;
+import minecrafttransportsimulator.baseclasses.RotationMatrix;
 import minecrafttransportsimulator.blocks.components.ABlockBase.Axis;
 import minecrafttransportsimulator.entities.instances.EntityBullet;
 import minecrafttransportsimulator.entities.instances.EntityBullet.HitType;
@@ -20,14 +21,20 @@ public class PacketEntityBulletHitGeneric extends APacketBase {
     private final UUID gunID;
     private final int bulletNumber;
     private final Point3D position;
+    private final RotationMatrix orientation;
     private final Axis hitSide;
     private final HitType hitType;
 
     public PacketEntityBulletHitGeneric(PartGun gun, int bulletNumber, Point3D position, Axis hitSide, HitType hitType) {
+        this(gun, bulletNumber, position, getBulletOrientation(gun, bulletNumber), hitSide, hitType);
+    }
+
+    public PacketEntityBulletHitGeneric(PartGun gun, int bulletNumber, Point3D position, RotationMatrix orientation, Axis hitSide, HitType hitType) {
         super(null);
         this.gunID = gun.uniqueUUID;
         this.bulletNumber = bulletNumber;
-        this.position = position;
+        this.position = position.copy();
+        this.orientation = new RotationMatrix().set(orientation);
         this.hitSide = hitSide;
         this.hitType = hitType;
     }
@@ -39,6 +46,7 @@ public class PacketEntityBulletHitGeneric extends APacketBase {
         this.position = readPoint3dFromBuffer(buf);
         this.hitType = HitType.values()[buf.readByte()];
         this.hitSide = Axis.values()[buf.readByte()];
+        this.orientation = buf.readableBytes() >= 9 * Double.BYTES ? readRotationMatrixFromBuffer(buf) : null;
     }
 
     @Override
@@ -49,10 +57,44 @@ public class PacketEntityBulletHitGeneric extends APacketBase {
         writePoint3dToBuffer(position, buf);
         buf.writeByte(hitType.ordinal());
         buf.writeByte(hitSide.ordinal());
+        writeRotationMatrixToBuffer(orientation, buf);
     }
 
     @Override
     public void handle(AWrapperWorld world) {
-        EntityBullet.performGenericHitLogic(world.getBulletGun(gunID), bulletNumber, position, hitSide, hitType);
+        EntityBullet.performGenericHitLogic(world.getBulletGun(gunID), bulletNumber, position, orientation, hitSide, hitType);
+    }
+
+    private static RotationMatrix getBulletOrientation(PartGun gun, int bulletNumber) {
+        EntityBullet bullet = gun.world.getBullet(gun.uniqueUUID, bulletNumber);
+        return bullet != null ? bullet.orientation : new RotationMatrix();
+    }
+
+    private static void writeRotationMatrixToBuffer(RotationMatrix matrix, ByteBuf buf) {
+        buf.writeDouble(matrix.m00);
+        buf.writeDouble(matrix.m01);
+        buf.writeDouble(matrix.m02);
+        buf.writeDouble(matrix.m10);
+        buf.writeDouble(matrix.m11);
+        buf.writeDouble(matrix.m12);
+        buf.writeDouble(matrix.m20);
+        buf.writeDouble(matrix.m21);
+        buf.writeDouble(matrix.m22);
+    }
+
+    private static RotationMatrix readRotationMatrixFromBuffer(ByteBuf buf) {
+        RotationMatrix matrix = new RotationMatrix();
+        matrix.m00 = buf.readDouble();
+        matrix.m01 = buf.readDouble();
+        matrix.m02 = buf.readDouble();
+        matrix.m10 = buf.readDouble();
+        matrix.m11 = buf.readDouble();
+        matrix.m12 = buf.readDouble();
+        matrix.m20 = buf.readDouble();
+        matrix.m21 = buf.readDouble();
+        matrix.m22 = buf.readDouble();
+        matrix.convertToAngles();
+        matrix.updateToAngles();
+        return matrix;
     }
 }


### PR DESCRIPTION
If you noticed earlier, with hitbox visibility enabled, or using particles, you could see that they were spawning at the entity's feet, which is why the bullet's position and orientation are now used instead of the entity's position.